### PR TITLE
Add Claude Code plugin marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "sonilo-skills",
+  "owner": {
+    "name": "Sonilo AI",
+    "email": "info@sonilo.com"
+  },
+  "description": "Sonilo — Agent Skills for licensed music, sound-effects, dubbing, and audio-ducking generation, scored to your video's pacing and emotion.",
+  "plugins": [
+    {
+      "name": "skills",
+      "source": "./",
+      "description": "Agent Skills for Sonilo's licensed music, sound-effects, dubbing, and audio-ducking API.",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "skills",
+  "displayName": "Sonilo Skills",
+  "version": "1.0.0",
+  "description": "Agent Skills for Sonilo's licensed music, sound-effects, dubbing, and audio-ducking API — text-to-music, video-to-music, sound effects, video-to-sound, dubbing, ducking, account, and setup.",
+  "author": {
+    "name": "Sonilo AI",
+    "url": "https://sonilo.com"
+  },
+  "homepage": "https://github.com/sonilo-ai/skills",
+  "repository": "https://github.com/sonilo-ai/skills",
+  "license": "MIT",
+  "keywords": ["music", "sound-effects", "audio", "video-to-music", "dubbing", "sonilo"],
+  "skills": [
+    "./music",
+    "./sound-effects",
+    "./video-to-sound",
+    "./audio-ducking",
+    "./dubbing",
+    "./task-recovery",
+    "./account",
+    "./audio-playback",
+    "./setup-api-key"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Sonilo's flagship capability is **video-to-music**: hand it a finished video and
 
 ## Installation
 
+These skills follow the community [Agent Skills specification](https://agentskills.io/specification), so any compatible tool can install them via `npx skills add`. This repo is also set up as a **Claude Code plugin marketplace**, so Claude Code users can install the same skills with `/plugin` instead — pick whichever fits your workflow.
+
+### Option 1: `npx skills` (any compatible assistant)
+
 ```bash
 npx skills add sonilo-ai/skills
 ```
@@ -17,6 +21,15 @@ Or install a single skill:
 ```bash
 npx skills add sonilo-ai/skills/music
 ```
+
+### Option 2: Claude Code plugin
+
+```
+/plugin marketplace add sonilo-ai/skills
+/plugin install skills@sonilo-skills
+```
+
+This installs the same nine skills (`music`, `sound-effects`, `video-to-sound`, `audio-ducking`, `dubbing`, `task-recovery`, `account`, `audio-playback`, `setup-api-key`) as a single Claude Code plugin, discovered directly from their existing top-level directories — no separate copy to keep in sync. It's a skills-only plugin (no MCP server, no bundled tools); see [Configuration](#configuration) below for how to connect the Sonilo MCP server itself.
 
 ## Available Skills
 


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` so this repo is installable as a Claude Code plugin marketplace via `/plugin marketplace add sonilo-ai/skills` — a separate, Anthropic-specific install mechanism from the `npx skills add sonilo-ai/skills` (Agent Skills spec) path this repo already supports.
- The existing top-level skill directories (`music/`, `sound-effects/`, `video-to-sound/`, `audio-ducking/`, `dubbing/`, `task-recovery/`, `account/`, `audio-playback/`, `setup-api-key/`) are **not restructured**. `plugin.json`'s `skills` field points directly at them, per Claude Code's documented pattern for a marketplace/plugin whose `source` is the repo root (see [plugins-reference](https://code.claude.com/docs/en/plugins-reference#component-path-fields) and [plugin-marketplaces#advanced-plugin-entries](https://code.claude.com/docs/en/plugin-marketplaces#advanced-plugin-entries)).
- README updated to document the new install path (`/plugin marketplace add` + `/plugin install skills@sonilo-skills`) alongside the existing `npx skills add` method.
- This is a skills-only plugin — no MCP server, no bundled tools. It's a companion to (not a replacement for) [`sonilo-ai/sonilo-claude-plugin`](https://github.com/sonilo-ai/sonilo-claude-plugin), which ships the actual MCP server; that repo's marketplace is named `sonilo`, so this one is named `sonilo-skills` to avoid a marketplace-name collision for users who install both.

Ran `claude plugin validate . --strict` locally against the new marketplace/plugin manifests — passes with no warnings.

## Test plan

- [ ] `claude plugin validate .` passes (confirmed locally, exit 0, no warnings)
- [ ] `/plugin marketplace add sonilo-ai/skills` followed by `/plugin install skills@sonilo-skills` in a real Claude Code session, then confirm all 9 skills are discovered (`/plugin` detail view or `claude plugin list`)
- [ ] Spot check that `npx skills add sonilo-ai/skills` still works unchanged