### PR TITLE
Add routing evals for the five ambiguous skill choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,20 @@ Tools marked with a cost warning make an API call that may incur charges. Self-s
 
 ## Evaluations
 
-Not yet included in this repo. Contributions welcome — the intent is trigger evals (does the right skill fire for the right query) and functional evals (does the tool call produce correct output) per skill.
+[`evals/`](./evals) holds five trigger evals — does the right skill fire for the
+right query — covering the routing decisions the v2 split put at risk, including
+the combined music+SFX request that must reach `video-to-sound` rather than
+billing twice for the two separate skills.
+
+```bash
+claude plugin eval skills@sonilo-skills
+```
+
+`claude plugin eval` is in early access and does not run yet; the cases are
+schema-valid and their assumptions verified headlessly. See
+[evals/README.md](./evals/README.md) for what was checked and how. Functional
+evals — does the call produce correct audio — are still open; contributions
+welcome.
 
 ## License
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,69 @@
+# Routing evals
+
+Five trigger evals: does the right skill fire for the right query? They exist
+because the v2 rename split two skills into four, and a split only pays for
+itself if each half still wins the queries it should. A skill that never loads
+is worse than one that is merely imperfect, and nothing else in this repo can
+catch that — `tests/validate.py` checks what the prose *claims*, not what an
+agent *does* with it.
+
+| Case | Prompt is about | Must load | Must not load |
+|---|---|---|---|
+| `routing/video-scoring` | a finished video needing a soundtrack | `video-to-music` | `text-to-music` |
+| `routing/text-only-music` | a beat for an audio-only podcast | `text-to-music` | `video-to-music` |
+| `routing/video-sfx` | foley matched to a fight scene | `video-to-sfx` | `text-to-sfx` |
+| `routing/dubbing` | localizing a demo into two languages | `auto-dubbing` | — |
+| `routing/music-and-sfx` | one video needing music **and** SFX | `video-to-sound` | `video-to-music`, `video-to-sfx` |
+
+The last one is the case worth having. Splitting `sound-effects` and `music`
+created two plausible-but-wrong answers for a combined request, and taking them
+separately bills the user twice for what `video_to_sound` does in one charge.
+
+## Running them
+
+```bash
+claude plugin eval skills@sonilo-skills          # or a path, or plugin@marketplace
+claude plugin eval . --case 'routing-*' --runs 3
+```
+
+**`claude plugin eval` is in early access and refuses to run as of CLI 2.1.231**,
+so these cases are schema-valid but have not been executed by the harness. What
+*has* been verified is every assumption they rest on:
+
+- The schema itself is transcribed from the CLI's own validator in 2.1.231
+  (`schema_version` 1.1; grader types `regex`, `tool_order`, `tool_used`,
+  `file_exists`, `llm`, `baseline`), because the format is not yet documented
+  publicly. Re-check it when the feature ships.
+- `tool_used` compares the tool name exactly and tests `input_match` as a JS
+  RegExp against the serialized tool input.
+- A skill invocation records as tool `Skill` with input
+  `{"skill": "skills:<name>"}` — confirmed by running the video-scoring prompt
+  headlessly and reading the tool call off the stream:
+
+  ```bash
+  claude -p '<prompt>' --output-format stream-json --verbose
+  ```
+
+  All five prompts were checked this way against the plugin installed from a
+  local marketplace, and each loaded its intended skill.
+
+## These cases cannot spend money
+
+Sonilo's generation tools are `mcp__*`, which the runner gates behind an
+explicit `--allow-tools` grant, and each case additionally sets
+`allowed_tools: ["Skill"]`. An agent under these cases can load a skill and talk
+about it; it cannot call a paid endpoint. Keep it that way — a routing eval that
+bills per run will not get run.
+
+`arm: with-only` on every grader is deliberate. The ablation's baseline arm has
+no Sonilo skills installed, so "did it load `video-to-music`" is a guaranteed
+fail there that measures nothing.
+
+## Adding a case
+
+One directory per case under `evals/`, each holding a `case.yaml`. Write the
+prompt the way a user would actually say it — no skill names, no "which skill
+would you pick", since naming the choice is the thing being measured. Pair every
+`loads-X` grader with an `avoids-Y` grader for whichever wrong skill is most
+tempting; a case that only asserts the positive passes even when the agent loads
+three skills to get there.

--- a/evals/routing/dubbing/case.yaml
+++ b/evals/routing/dubbing/case.yaml
@@ -1,0 +1,29 @@
+schema_version: "1.1"
+name: routing-dubbing
+description: >-
+  Localizing a video must load auto-dubbing. The capability keeps the tool name
+  `dubbing` while the skill is now `auto-dubbing`, so this case guards the
+  rename specifically.
+tags: [routing, dubbing]
+
+execution:
+  prompt: |
+    We need our product demo video localized into Spanish and Japanese, with the
+    speech actually re-voiced rather than subtitled. Can you help?
+  allowed_tools: ["Skill"]
+  max_turns: 4
+  timeout_seconds: 120
+
+runs: 3
+
+graders:
+  - type: tool_used
+    name: loads-auto-dubbing
+    tool: Skill
+    input_match: "skills:auto-dubbing"
+    min: 1
+    arm: with-only
+
+expected_outcome: >-
+  Loads auto-dubbing and surfaces the per-language, no-free-trial billing before
+  suggesting a call.

--- a/evals/routing/music-and-sfx/case.yaml
+++ b/evals/routing/music-and-sfx/case.yaml
@@ -1,0 +1,44 @@
+schema_version: "1.1"
+name: routing-music-and-sfx
+description: >-
+  The hardest case, and the one the v2 split put at risk. Asking for music *and*
+  SFX on one video must load video-to-sound — a single balanced, single-charge
+  call — rather than reaching for the two newly separated skills and billing the
+  user twice.
+tags: [routing, music, sfx, cost]
+
+execution:
+  prompt: |
+    My video needs a full soundtrack: background music and sound effects both.
+    What's the most efficient way to do that?
+  allowed_tools: ["Skill"]
+  max_turns: 4
+  timeout_seconds: 120
+
+runs: 3
+
+graders:
+  - type: tool_used
+    name: loads-video-to-sound
+    tool: Skill
+    input_match: "skills:video-to-sound"
+    min: 1
+    arm: with-only
+  # Loading either half separately is the double-charge failure this case exists
+  # to catch.
+  - type: tool_used
+    name: avoids-video-to-music
+    tool: Skill
+    input_match: "skills:video-to-music"
+    max: 0
+    arm: with-only
+  - type: tool_used
+    name: avoids-video-to-sfx
+    tool: Skill
+    input_match: "skills:video-to-sfx"
+    max: 0
+    arm: with-only
+
+expected_outcome: >-
+  Loads video-to-sound only, and explains that it bills once for both layers
+  instead of chaining two generations.

--- a/evals/routing/text-only-music/case.yaml
+++ b/evals/routing/text-only-music/case.yaml
@@ -1,0 +1,35 @@
+schema_version: "1.1"
+name: routing-text-only-music
+description: >-
+  Music with no video must load text-to-music. This is the half of the old
+  `music` skill that the split was meant to make cheap — routing here should not
+  drag in the video-scoring surface.
+tags: [routing, music]
+
+execution:
+  prompt: |
+    I need a 10-second lo-fi chill beat for my podcast intro. There's no video
+    involved, it's an audio-only show. How would you go about it?
+  allowed_tools: ["Skill"]
+  max_turns: 4
+  timeout_seconds: 120
+
+runs: 3
+
+graders:
+  - type: tool_used
+    name: loads-text-to-music
+    tool: Skill
+    input_match: "skills:text-to-music"
+    min: 1
+    arm: with-only
+  - type: tool_used
+    name: avoids-video-to-music
+    tool: Skill
+    input_match: "skills:video-to-music"
+    max: 0
+    arm: with-only
+
+expected_outcome: >-
+  Loads text-to-music and asks for or uses an explicit duration, without loading
+  video-to-music.

--- a/evals/routing/video-scoring/case.yaml
+++ b/evals/routing/video-scoring/case.yaml
@@ -1,0 +1,43 @@
+schema_version: "1.1"
+name: routing-video-scoring
+description: >-
+  A finished video that needs a soundtrack must load video-to-music. Before the
+  v2 split this was the `music` skill, which also carried text_to_music — the
+  split only pays off if the video case still routes to the video skill.
+tags: [routing, music]
+
+execution:
+  # Deliberately phrased the way a user would, with no skill name and no "which
+  # skill would you pick" framing: naming the choice is what we are measuring.
+  prompt: |
+    I've got a finished 30-second product trailer at ~/Desktop/trailer.mp4.
+    I'd like an original soundtrack that follows the cut. Where do we start?
+  # The allowlist is the money guard: Sonilo's generation tools are `mcp__*`,
+  # which the runner gates behind an explicit --allow-tools grant, and they are
+  # not listed here either. A routing eval must never be able to spend credits.
+  allowed_tools: ["Skill"]
+  max_turns: 4
+  timeout_seconds: 120
+
+runs: 3
+
+graders:
+  # `arm: with-only` because the baseline arm has no Sonilo skills installed at
+  # all — grading "did it load video-to-music" there is a guaranteed fail that
+  # measures nothing.
+  - type: tool_used
+    name: loads-video-to-music
+    tool: Skill
+    input_match: "skills:video-to-music"
+    min: 1
+    arm: with-only
+  - type: tool_used
+    name: avoids-text-to-music
+    tool: Skill
+    input_match: "skills:text-to-music"
+    max: 0
+    arm: with-only
+
+expected_outcome: >-
+  Loads video-to-music and describes scoring the existing cut, without loading
+  text-to-music.

--- a/evals/routing/video-sfx/case.yaml
+++ b/evals/routing/video-sfx/case.yaml
@@ -1,0 +1,34 @@
+schema_version: "1.1"
+name: routing-video-sfx
+description: >-
+  Sound design matched to footage must load video-to-sfx, the video half of the
+  old `sound-effects` skill.
+tags: [routing, sfx]
+
+execution:
+  prompt: |
+    I have a silent fight-scene clip that needs footsteps, punches and impacts
+    landing on the action. What's the approach?
+  allowed_tools: ["Skill"]
+  max_turns: 4
+  timeout_seconds: 120
+
+runs: 3
+
+graders:
+  - type: tool_used
+    name: loads-video-to-sfx
+    tool: Skill
+    input_match: "skills:video-to-sfx"
+    min: 1
+    arm: with-only
+  - type: tool_used
+    name: avoids-text-to-sfx
+    tool: Skill
+    input_match: "skills:text-to-sfx"
+    max: 0
+    arm: with-only
+
+expected_outcome: >-
+  Loads video-to-sfx and raises timed `segments` for pinning sounds to moments,
+  without loading text-to-sfx.


### PR DESCRIPTION
## What

Five trigger evals under [`evals/`](../tree/evals/routing-triggers/evals) — does the right skill fire for the right query — filling the gap the README's Evaluations section has been holding open.

| Case | Prompt is about | Must load | Must not load |
|---|---|---|---|
| `routing/video-scoring` | a finished video needing a soundtrack | `video-to-music` | `text-to-music` |
| `routing/text-only-music` | a beat for an audio-only podcast | `text-to-music` | `video-to-music` |
| `routing/video-sfx` | foley matched to a fight scene | `video-to-sfx` | `text-to-sfx` |
| `routing/dubbing` | localizing a demo into two languages | `auto-dubbing` | — |
| `routing/music-and-sfx` | one video needing music **and** SFX | `video-to-sound` | `video-to-music`, `video-to-sfx` |

## Why

#5 split two skills into four. A split only pays for itself if each half still wins the queries it should, and `tests/validate.py` checks what the prose *claims*, not what an agent *does* with it.

The last case is the one worth having: splitting `sound-effects` and `music` created two plausible-but-wrong answers for a combined request, and taking them separately bills the user twice for what `video_to_sound` does in one charge. Every positive grader is paired with an `avoids-` grader — a case asserting only the positive still passes when the agent loads three skills to get there.

## These cases cannot spend money

Generation tools are `mcp__*`, which the runner gates behind an explicit `--allow-tools` grant, and each case additionally pins `allowed_tools: ["Skill"]`. An agent under these cases can load a skill and talk about it; it cannot call a paid endpoint.

## Honest status

**`claude plugin eval` is in early access and refuses to run as of CLI 2.1.231**, so these cases are schema-valid but have not been executed by the harness. Everything they rest on was verified instead:

- The schema is transcribed from the CLI's own zod validator (`schema_version` 1.1; grader types `regex`, `tool_order`, `tool_used`, `file_exists`, `llm`, `baseline`) because the format is not documented publicly yet. `evals/README.md` says to re-check it when the feature ships.
- `tool_used` compares the tool name exactly and tests `input_match` as a JS RegExp against the serialized tool input.
- A skill invocation records as tool `Skill` with input `{"skill": "skills:<name>"}` — read off a real `--output-format stream-json` run.
- All five prompts were checked headlessly against the plugin installed from a local marketplace; each loaded its intended skill.

Prompts are phrased the way a user would actually say it — no skill names, no "which skill would you pick", since naming the choice is the thing being measured.

## Follow-up

Functional evals — does the call produce correct audio — remain open. Those need a paid-call budget and a fixture video, so they are a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)