### PR TITLE
The video-to-video CLI commands exist, and make that checkable

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ repo has no build to break: every claim in here is prose, and prose about
 another repo's API goes stale silently. It has already caught, on its first
 run, a recovery tool named for only one of the two servers, three
 behaviour-changing parameters documented nowhere, a `ducking` default that had
-been flipped upstream a release earlier, and a key prefix that was never right.
+been flipped upstream a release earlier, and a key prefix that was never right. The CLI check was added after six "no CLI command for video_to_video_*" lines outlived the release that added both commands and then survived a full repo restructure by moving to new files.
 
 ```bash
 python tests/validate.py             # offline; what CI runs on every push
@@ -21,6 +21,7 @@ python tests/validate.py --refresh   # needs `pip install sonilo-mcp`; re-reads
 | Tool names | A tool that exists on neither server; naming `get_sfx_task` without `get_generation_task` (or the reverse) — the two servers use different names for the same tool, so a doc that knows only one breaks for half the users |
 | Parameters | A parameter passed in an example that the tool does not have; a behaviour- or cost-changing parameter missing from the skill that covers it (`must_document`) |
 | Defaults | A documented default that contradicts the server's schema |
+| CLI claims | A "no CLI command for X" line that is no longer true, and any `sonilo <subcommand>` that does not exist |
 | Banned tokens | Strings that were true once — see `banned_tokens` in `tool_surface.json` |
 
 ## Keeping it honest

--- a/tests/tool_surface.json
+++ b/tests/tool_surface.json
@@ -196,6 +196,53 @@
       "input_file_path"
     ]
   },
+  "cli": {
+    "_comment": [
+      "Subcommands the published CLIs expose, from `sonilo --help` on both",
+      "npm sonilo-cli and PyPI sonilo-cli (they are kept identical).",
+      "Recorded because this repo repeatedly claimed a command did not exist",
+      "after it shipped: six 'no CLI command for video_to_video_*' lines",
+      "survived a whole repo restructure. A claim about the CLI is now",
+      "checkable, the same way a claim about a tool already was."
+    ],
+    "commands": [
+      "login",
+      "logout",
+      "whoami",
+      "account",
+      "usage",
+      "text-to-music",
+      "video-to-music",
+      "text-to-sfx",
+      "video-to-sfx",
+      "video-to-sound",
+      "video-to-video-music",
+      "video-to-video-sfx",
+      "video-to-video-sound",
+      "dubbing",
+      "tasks"
+    ],
+    "tool_to_command": {
+      "text_to_music": "text-to-music",
+      "video_to_music": "video-to-music",
+      "text_to_sfx": "text-to-sfx",
+      "video_to_sfx": "video-to-sfx",
+      "video_to_sound": "video-to-sound",
+      "video_to_video_music": "video-to-video-music",
+      "video_to_video_sfx": "video-to-video-sfx",
+      "video_to_video_sound": "video-to-video-sound",
+      "dubbing": "dubbing",
+      "get_sfx_task": "tasks",
+      "get_generation_task": "tasks",
+      "get_account_services": "account",
+      "get_usage": "usage"
+    },
+    "no_command": {
+      "_comment": "Tools with genuinely no CLI equivalent. Saying so is allowed only for these.",
+      "audio_ducking": true,
+      "play_audio": true
+    }
+  },
   "defaults": {
     "_comment": "Schema defaults, read from the installed server's inputSchema. Only booleans are machine-checkable today; a docs table stating the opposite fails the build.",
     "preserve_speech": "false",

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -204,6 +204,49 @@ def check_documented_defaults(surface: dict, docs: dict[Path, str]) -> None:
                                f"tool schema says {want!r}")
 
 
+def check_cli_claims(surface: dict, docs: dict[Path, str]) -> None:
+    """A "no CLI command" claim must be true, and a shown command must exist.
+
+    This check exists because six lines saying `video_to_video_music` and
+    `video_to_video_sfx` had no CLI command outlived the release that added
+    both, then survived a full repo restructure by moving to new files. The
+    claim reads as a fact and sends people to write SDK code instead of running
+    one command, and nothing here could see it: the manifest knew the tools but
+    not the CLI.
+    """
+    cli = surface.get("cli")
+    if not cli:
+        return
+    commands = set(cli["commands"])
+    genuinely_absent = {k for k in cli["no_command"] if not k.startswith("_")}
+    tool_to_command = cli["tool_to_command"]
+
+    for path, text in docs.items():
+        rel = path.relative_to(ROOT)
+
+        # 1. "no CLI command for X" is only allowed when X really has none.
+        for m in re.finditer(
+            r"no CLI command[^.]{0,80}?`(\w+)`|`(\w+)`[^.]{0,60}?has \*\*no CLI command", text
+        ):
+            tool = m.group(1) or m.group(2)
+            if tool in genuinely_absent:
+                continue
+            if tool in tool_to_command:
+                fail(str(rel), f"claims `{tool}` has no CLI command, but "
+                               f"`sonilo {tool_to_command[tool]}` exists")
+
+        # 2. Any `sonilo <subcommand>` shown must be a real subcommand. Only
+        #    shell invocations count: `from sonilo import Sonilo` is Python, and
+        #    matching it would report `import` as a missing subcommand in every
+        #    skill that shows the SDK.
+        for line in text.splitlines():
+            if "import" in line:
+                continue
+            m = re.search(r"(?:^|\$ |`)sonilo ([a-z][a-z-]{2,})\b", line)
+            if m and m.group(1) not in commands:
+                fail(str(rel), f"shows `sonilo {m.group(1)}`, which is not a CLI subcommand")
+
+
 def check_banned_tokens(surface: dict, docs: dict[Path, str]) -> None:
     for path, text in docs.items():
         rel = path.relative_to(ROOT)
@@ -257,6 +300,7 @@ def main() -> int:
     check_tool_names(surface, docs)
     check_parameters(surface, docs)
     check_documented_defaults(surface, docs)
+    check_cli_claims(surface, docs)
     check_banned_tokens(surface, docs)
     check_key_prefix(docs)
 

--- a/video-to-music/SKILL.md
+++ b/video-to-music/SKILL.md
@@ -40,7 +40,7 @@ client = Sonilo()  # reads SONILO_API_KEY
 score = client.video_to_music.generate(video="trailer.mp4", prompt="Build suspense, then resolve with a warm cinematic finish")
 score.save("score.m4a")
 
-# video_to_video_music has no CLI command — this is the only non-MCP way to get the muxed video back
+# video_to_video_music: get the video back with the music muxed in
 video = client.video_to_video_music.generate(video="trailer.mp4", prompt="cinematic, uplifting")
 video.save("scored.mp4")
 ```
@@ -59,7 +59,7 @@ const score = await client.videoToMusic.generate({
   prompt: "Build suspense, then resolve with a warm cinematic finish",
 });
 
-// video_to_video_music has no CLI command — this is the only non-MCP way to get the muxed video back
+// video_to_video_music: get the video back with the music muxed in
 const video = await client.videoToVideoMusic.generate({
   video: "./trailer.mp4",
   prompt: "cinematic, uplifting",
@@ -74,7 +74,12 @@ const video = await client.videoToVideoMusic.generate({
 sonilo video-to-music --video trailer.mp4 --prompt "Build suspense, then resolve with a warm cinematic finish" --output score.m4a
 ```
 
-`--format wav`, `--preserve-speech`, and `--isolate-vocals` each switch `video-to-music` to the async submit-and-poll path. **There is no CLI command for `video_to_video_music`** (the video-to-video variants aren't exposed by either CLI) — use the Python/JS SDK or the MCP tool for that.
+`--format wav`, `--preserve-speech`, and `--isolate-vocals` each switch `video-to-music` to the async submit-and-poll path.
+
+```bash
+# the muxed video, from the CLI
+sonilo video-to-video-music --video trailer.mp4 --prompt "cinematic, uplifting" --output scored.mp4
+```
 
 ### cURL (raw REST API, no MCP host)
 

--- a/video-to-sfx/SKILL.md
+++ b/video-to-sfx/SKILL.md
@@ -37,7 +37,7 @@ client = Sonilo()  # reads SONILO_API_KEY
 foley = client.video_to_sfx.generate(video="action-scene.mp4", prompt="Footsteps on gravel, distant traffic, a door slam")
 foley.save("foley.wav")
 
-# video_to_video_sfx has no CLI command — this is the only non-MCP way to get the muxed video back
+# video_to_video_sfx: get the video back with the effects muxed in
 video = client.video_to_video_sfx.generate(video="action-scene.mp4", segments=[{"start": 0, "end": 2, "prompt": "footsteps on gravel"}])
 video.save("with_sfx.mp4")
 ```
@@ -54,7 +54,7 @@ const foley = await client.videoToSfx.generate({
   prompt: "Footsteps on gravel, distant traffic, a door slam",
 });
 
-// video_to_video_sfx has no CLI command — this is the only non-MCP way to get the muxed video back
+// video_to_video_sfx: get the video back with the effects muxed in
 const video = await client.videoToVideoSfx.generate({
   video: "./action-scene.mp4",
   segments: [{ start: 0, end: 2, prompt: "footsteps on gravel" }],
@@ -67,7 +67,12 @@ const video = await client.videoToVideoSfx.generate({
 sonilo video-to-sfx --video action-scene.mp4 --output foley.wav
 ```
 
-Always async under the hood — the CLI submits and polls for you. `--format` accepts `wav|mp3|aac|flac`. **There is no CLI command for `video_to_video_sfx`** (the video-to-video variants aren't exposed by either CLI) — use the Python/JS SDK or the MCP tool for that.
+Always async under the hood — the CLI submits and polls for you. `--format` accepts `wav|mp3|aac|flac`.
+
+```bash
+# the muxed video, from the CLI
+sonilo video-to-video-sfx --video clip.mp4 --prompt "footsteps, distant thunder" --output foley.mp4
+```
 
 ### cURL (raw REST API, no MCP host)
 


### PR DESCRIPTION
Six lines in the repo said `video_to_video_music` and `video_to_video_sfx` had **no CLI command**. Both CLIs shipped those commands; the lines outlived that release and then survived the one-skill-per-tool restructure by moving to new files (`music/` → `video-to-music/`, `sound-effects/` → `video-to-sfx/`).

They read as statements of fact, so their effect was to send readers off to write SDK code for something one command already does:

```bash
sonilo video-to-video-music --video trailer.mp4 --prompt "cinematic, uplifting" --output scored.mp4
sonilo video-to-video-sfx  --video clip.mp4    --prompt "footsteps, distant thunder" --output foley.mp4
```

Verified against `sonilo --help` on both published CLIs (npm `sonilo-cli` 0.12.0, PyPI `sonilo-cli` 0.11.0), which expose an identical command set.

## Why the validator missed it

It knew both MCP tool surfaces and nothing at all about the CLI, so a claim about the CLI was unfalsifiable. `tests/tool_surface.json` now records:

- the published CLIs' subcommands, and
- `no_command`: the tools that genuinely have no CLI equivalent — `audio_ducking` and `play_audio`, the only two. `audio-ducking/SKILL.md` says so and is left alone, because there it is still true.

`check_cli_claims` fails a "no CLI command for X" line that is no longer true, and any `sonilo <subcommand>` that does not exist.

## Notes

- The check's first run produced **eight false positives** from `from sonilo import Sonilo` in the Python examples — it now matches only shell invocations (line start, `$ `, or a backtick), skipping any line containing `import`.
- Verified negatively as well: reintroducing the exact stale sentence plus an invented `sonilo score-video` fails the build and names both. That is the rule `tests/README.md` sets — when you add a check, add the case that would have caught the bug you just fixed by hand.

`python tests/validate.py` passes: 16 files, 11 skills, 13 hosted tools, 14 local tools.