### PR TITLE
content: audio_ducking now has SDK resources and a CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Sonilo also ships official client libraries, independent of MCP:
 
 Both SDKs read `SONILO_API_KEY` from the environment by default; both CLIs additionally fall back to a `sonilo login` credential when it is not set. Each skill's Quick Start includes Python, JavaScript, and (where a command exists) CLI examples alongside the MCP tool call and raw cURL — use whichever matches your integration; they all hit the same underlying API.
 
-Every generation tool has a 1:1 SDK resource and CLI command (`audio_ducking`, the last holdout, gained both in Python SDK 0.13 / JS SDK 0.14 / CLI 0.12). The one deliberate exception is `play_audio`, which just plays a local file — MCP-only by nature. Where a skill's SDK/CLI coverage differs from its MCP tool in any other way, the skill says so explicitly rather than implying full parity.
+Every generation tool has a 1:1 SDK resource and CLI command (`audio_ducking`, the last holdout, gained both in Python SDK 0.13 / JS SDK 0.14, with the CLI command in PyPI `sonilo-cli` 0.12 / npm `sonilo-cli` 0.13). The one deliberate exception is `play_audio`, which just plays a local file — MCP-only by nature. Where a skill's SDK/CLI coverage differs from its MCP tool in any other way, the skill says so explicitly rather than implying full parity.
 
 ## Billing
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Sonilo also ships official client libraries, independent of MCP:
 
 Both SDKs read `SONILO_API_KEY` from the environment by default; both CLIs additionally fall back to a `sonilo login` credential when it is not set. Each skill's Quick Start includes Python, JavaScript, and (where a command exists) CLI examples alongside the MCP tool call and raw cURL — use whichever matches your integration; they all hit the same underlying API.
 
-Not every MCP tool has a 1:1 SDK/CLI equivalent — most notably `audio_ducking` has no dedicated SDK resource or CLI command (see the [audio-ducking](./audio-ducking) skill for the closest equivalents). Where a skill's SDK/CLI coverage differs from its MCP tool, the skill says so explicitly rather than implying full parity.
+Every generation tool has a 1:1 SDK resource and CLI command (`audio_ducking`, the last holdout, gained both in Python SDK 0.13 / JS SDK 0.14 / CLI 0.12). The one deliberate exception is `play_audio`, which just plays a local file — MCP-only by nature. Where a skill's SDK/CLI coverage differs from its MCP tool in any other way, the skill says so explicitly rather than implying full parity.
 
 ## Billing
 

--- a/audio-ducking/SKILL.md
+++ b/audio-ducking/SKILL.md
@@ -24,30 +24,45 @@ audio_ducking(
 )
 ```
 
-### Python / JavaScript — no dedicated SDK method
+### Python (`pip install "sonilo>=0.13"`)
 
-Unlike every other tool in this repo, `audio_ducking` has **no dedicated resource** in either official SDK (no `client.audio_ducking` in Python, no `client.audioDucking` in JS) and **no CLI command**. Reach for one of these instead:
+```python
+from sonilo import Sonilo
 
-- **`sonilo-video-kit`'s `duck_music_under_speech()` / `duckMusicUnderSpeech()`** — the closest equivalent, but a different shape: it takes a video plus already-generated audio *bytes* (not two file paths/URLs) and calls this same ducking API internally, then re-muxes the result into a new video. See [sonilo-video-kit (Python)](https://github.com/sonilo-ai/sonilo-python/tree/main/sonilo-video-kit) / [sonilo-video-kit (JS)](https://github.com/sonilo-ai/sonilo-js/tree/main/packages/sonilo-video-kit).
-- **The JS SDK's generic `client.request()` escape hatch** — calls the raw endpoint directly with the same params as the MCP tool:
+client = Sonilo()  # reads SONILO_API_KEY
 
-  ```ts
-  import { SoniloClient } from "sonilo";
+result = client.audio_ducking.generate(
+    voice="interview.mp4",  # audio or video; also voice_url=
+    music="background-track.wav",  # audio only; also music_url=
+)
+result.save("ducked.mp4" if result.output_type == "video" else "ducked.wav")
+```
 
-  const client = new SoniloClient(); // reads SONILO_API_KEY
-  const res = await client.request("/v1/audio-ducking", {
-    method: "POST",
-    body: (() => {
-      const form = new FormData();
-      form.set("voice_url", "https://example.com/interview.mp4");
-      form.set("music_url", "https://example.com/background-track.wav");
-      return form;
-    })(),
-  });
-  const { task_id } = await res.json();
-  ```
+### JavaScript / TypeScript (`npm install sonilo@>=0.14`)
 
-  The Python SDK has no public equivalent of `client.request()` — call the REST endpoint directly with `httpx`/`requests` instead (see cURL below for the exact form fields).
+```ts
+import { SoniloClient, download } from "sonilo";
+import { writeFile } from "node:fs/promises";
+
+const client = new SoniloClient(); // reads SONILO_API_KEY
+
+const result = await client.audioDucking.generate({
+  voice: "./interview.mp4", // audio or video; also voiceUrl
+  musicUrl: "https://example.com/background-track.wav", // audio only; also music
+});
+await writeFile(
+  result.output_type === "video" ? "ducked.mp4" : "ducked.wav",
+  await download(result.output_url!),
+);
+```
+
+### CLI (`npm install -g sonilo-cli` or `pip install sonilo-cli`)
+
+```bash
+sonilo audio-ducking --voice interview.mp4 --music-url https://example.com/background-track.wav
+```
+
+Always async under the hood — the CLI submits and polls for you. Exactly one of `--voice`/`--voice-url` and one of `--music`/`--music-url`. The default output name follows what comes back (`output.wav`, or `output.mp4` when the voice input was a video); `--output` overrides it. A local `--music` file must have an audio extension — the CLI rejects a video there up front, for the same reason the MCP tool does.
 
 ### cURL (raw REST API, no MCP host)
 

--- a/tests/tool_surface.json
+++ b/tests/tool_surface.json
@@ -219,6 +219,7 @@
       "video-to-video-music",
       "video-to-video-sfx",
       "video-to-video-sound",
+      "audio-ducking",
       "dubbing",
       "tasks"
     ],
@@ -231,6 +232,7 @@
       "video_to_video_music": "video-to-video-music",
       "video_to_video_sfx": "video-to-video-sfx",
       "video_to_video_sound": "video-to-video-sound",
+      "audio_ducking": "audio-ducking",
       "dubbing": "dubbing",
       "get_sfx_task": "tasks",
       "get_generation_task": "tasks",
@@ -239,7 +241,6 @@
     },
     "no_command": {
       "_comment": "Tools with genuinely no CLI equivalent. Saying so is allowed only for these.",
-      "audio_ducking": true,
       "play_audio": true
     }
   },


### PR DESCRIPTION
## Summary

The SDKs grew a dedicated audio-ducking resource (\`client.audio_ducking\` in Python 0.13.0 — sonilo-python#29, \`client.audioDucking\` in JS 0.14.0 — sonilo-js#51) and both CLIs grew \`sonilo audio-ducking\` (CLI 0.12.0), closing the one generation-tool gap this repo had to document around.

- **audio-ducking/SKILL.md**: the "no dedicated SDK method / \`client.request()\` escape hatch" section is replaced with ordinary Python / JS / CLI quick starts, matching the other skills' structure (install lines pin the first versions that carry the resource).
- **tests/tool_surface.json**: \`audio-ducking\` added to the CLI commands and \`audio_ducking → audio-ducking\` to the tool→command map; \`audio_ducking\` dropped from the \`no_command\` whitelist, so any future "no CLI command" claim about it fails CI instead of going stale in the other direction.
- **README**: the "not every tool has an SDK/CLI equivalent" caveat now covers only \`play_audio\`, which is local playback and MCP-only by nature.

⚠️ **Merge after the SDK/CLI releases ship** (sonilo-js#51 → npm \`sonilo\` 0.14 / \`sonilo-cli\` 0.13, sonilo-python#29 → PyPI \`sonilo\` 0.13 / \`sonilo-cli\` 0.12): the quick starts name those versions, and until they are on npm/PyPI the commands do not exist for users.

\`python3 tests/validate.py\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)