### PR TITLE
Make the CLI a transport the agent will actually use

### DIFF
--- a/account/SKILL.md
+++ b/account/SKILL.md
@@ -2,7 +2,8 @@
 name: account
 description: Check the Sonilo account's available services, rate limits, free-trial allowance, and usage/billing history. Use before calling a paid Sonilo tool to confirm it's available and whether free-trial runs remain, or when the user asks about their Sonilo usage, limits, or billing.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected and Sonilo credentials — either a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+compatibility: Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
 ---
 
 # Sonilo Account
@@ -10,6 +11,15 @@ compatibility: Requires the Sonilo MCP server connected and Sonilo credentials �
 Two free, read-only tools for checking what a Sonilo account can do and how much it's used. Neither makes a charge.
 
 > **Setup:** See the [setup-api-key](../setup-api-key) skill.
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`get_account_services` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
+2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start
 

--- a/audio-ducking/SKILL.md
+++ b/audio-ducking/SKILL.md
@@ -2,7 +2,8 @@
 name: audio-ducking
 description: Duck a music bed under a voice track using Sonilo — automatically lowers the music wherever the voice speaks and lifts it back in the gaps. Use when mixing a separately-generated or existing music track under narration, dialogue, or a video's own voice track, without manual volume automation.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected and Sonilo credentials — either a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+compatibility: Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
 ---
 
 # Sonilo Audio Ducking
@@ -12,6 +13,15 @@ Automatically duck a music bed under a voice track: Sonilo lowers the music wher
 > **Setup:** See the [setup-api-key](../setup-api-key) skill.
 
 > ⚠️ **Cost:** makes an API call that may incur charges. Only call when explicitly requested.
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`audio_ducking` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
+2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start
 

--- a/audio-playback/SKILL.md
+++ b/audio-playback/SKILL.md
@@ -2,7 +2,8 @@
 name: audio-playback
 description: Play a local audio file through the system's default speakers using Sonilo's MCP server. Use after generating a track with Sonilo (or for any local WAV/MP3/M4A/AAC/OGG/FLAC file) when the user wants to hear it immediately instead of just getting the saved path.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected. Does not require SONILO_API_KEY or network access — playback is entirely local. macOS and Linux use a native system player (afplay / mpg123 or aplay) when available; on Windows, and on Linux without a native player, this falls back to the sounddevice and soundfile Python packages plus PortAudio (brew install portaudio on macOS / apt-get install libportaudio2 on Debian-Ubuntu).
+compatibility: Requires the Sonilo MCP server connected — this is the one skill with no CLI equivalent, since `play_audio` exists only as an MCP tool. Does not require SONILO_API_KEY or network access — playback is entirely local. macOS and Linux use a native system player (afplay / mpg123 or aplay) when available; on Windows, and on Linux without a native player, this falls back to the sounddevice and soundfile Python packages plus PortAudio (brew install portaudio on macOS / apt-get install libportaudio2 on Debian-Ubuntu).
+allowed-tools: Bash, Read, mcp__sonilo__*
 ---
 
 # Sonilo Audio Playback

--- a/auto-dubbing/SKILL.md
+++ b/auto-dubbing/SKILL.md
@@ -2,7 +2,8 @@
 name: auto-dubbing
 description: Dub a video into one or more other languages using Sonilo, translating and re-voicing the speech into a new video per language. Use when a user needs a video localized into another language, not just subtitled. Billed per language with zero free trial — confirm language count with the user before calling.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected and Sonilo credentials — either a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+compatibility: Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
 ---
 
 # Sonilo Dubbing
@@ -14,6 +15,30 @@ Dub a video into one or more other languages: the speech is translated and re-vo
 > ⚠️ **Cost — read before calling:** this is billed **per language**, with **zero free-trial runs** — even a trial account is charged from the very first call, unlike every other Sonilo tool. Requesting four languages costs four times as much as one. Confirm the exact language list with the user before calling; do not guess a long list "to be helpful."
 
 > ⏱ **This call is slow.** It polls for **at least two hours** internally regardless of any shorter `TIME_OUT_SECONDS` — that's the backend's own ceiling for the dubbing pipeline. A call that sits for an hour or more is normal, not a hang. Do not cancel it: the job keeps running and charging either way, and cancelling just loses the easy path to the result (use `get_sfx_task`, or `get_generation_task` on the hosted server, to recover it instead).
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`dubbing` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
+2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
+
+> ⏱ **On the CLI path this call cannot be one command.** The backend polls for
+> up to two hours, while a host's shell tool is capped far below that (ten
+> minutes in Claude Code), so `sonilo dubbing` run in the foreground will be
+> killed with the job still running and already charged. Submit it and poll
+> separately instead:
+>
+> ```bash
+> # --timeout is the CLI's own wait, not the job's: it returns early and the
+> # task keeps running. The id comes from the "Submitted task ..." line.
+> sonilo dubbing --video-url https://example.com/clip.mp4 --languages es,fr --timeout 300000
+> sonilo tasks wait <task-id> --timeout 300000   # repeat until it finishes
+> ```
+>
+> The MCP path has no such limit and is the better transport for dubbing.
 
 ## Quick Start
 

--- a/setup-api-key/SKILL.md
+++ b/setup-api-key/SKILL.md
@@ -26,11 +26,14 @@ Choosing:
 
 Do this before changing anything — the answer is often "nothing to do".
 
-1. Check whether a `sonilo` MCP server is already connected (any Sonilo tool, e.g. `text_to_music` or `get_account_services`, is available to call).
-2. If tools exist, call the free, read-only `get_account_services()`.
-3. **Succeeds:** Sonilo is configured and working. Say so and stop. Ask only whether they want to rotate credentials.
+There are two transports, and either one is enough. Probe both before
+concluding that nothing is set up.
+
+1. **MCP:** is a `sonilo` MCP server connected (any Sonilo tool, e.g. `text_to_music` or `get_account_services`, available to call)? If so, call the free, read-only `get_account_services()`.
+2. **CLI:** if there are no Sonilo tools, run `sonilo whoami`. Exit code 0 means the CLI is installed and signed in, and the skills can drive it directly. Confirm with `sonilo account`, which is the same free call.
+3. **Either one succeeds:** Sonilo is configured and working. Say so and stop. Ask only whether they want to rotate credentials.
 4. **Fails with 401:** authentication is stale, not missing. If they signed in with `sonilo login`, the key may have expired (90 days) or been revoked — `sonilo login` again fixes it. Otherwise the key is wrong: continue at Path C.
-5. **No Sonilo tools at all:** nothing is connected — pick a path above and run it.
+5. **Neither responds:** nothing is connected — pick a path below and run it. MCP is the better default (it needs no shell, and it is the only transport that survives a dubbing job's two-hour poll), but a CLI that is installed and signed in is a complete setup on its own; do not make someone configure MCP they will not use.
 
 Never print, quote, or echo a key or the contents of the credential file. If you must refer to one, redact it.
 

--- a/task-recovery/SKILL.md
+++ b/task-recovery/SKILL.md
@@ -2,7 +2,8 @@
 name: task-recovery
 description: Recover the result of a timed-out Sonilo generation call using its task_id. Use whenever text_to_sfx, video_to_sfx, video_to_video_music, video_to_video_sfx, video_to_sound, video_to_video_sound, audio_ducking, dubbing, or video_to_music(preserve_speech=true) times out or its call was interrupted — the generation already ran (and was already charged) and its result is still retrievable.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected and Sonilo credentials — either a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+compatibility: Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
 ---
 
 # Sonilo Task Recovery
@@ -12,6 +13,15 @@ Every Sonilo generation that runs asynchronously on the backend (SFX, ducking, v
 > **Setup:** See the [setup-api-key](../setup-api-key) skill.
 
 > This tool is a safety net, not something to call speculatively. Only use it when you actually have a `task_id` — from a timeout error message, or from the `[sonilo-mcp] task submitted: <id>` line a host prints to stderr the moment a task is submitted (this survives even a cancelled call).
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`get_sfx_task` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
+2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,7 @@ python tests/validate.py --refresh   # needs `pip install sonilo-mcp`; re-reads
 | Tool names | A tool that exists on neither server; naming `get_sfx_task` without `get_generation_task` (or the reverse) — the two servers use different names for the same tool, so a doc that knows only one breaks for half the users |
 | Parameters | A parameter passed in an example that the tool does not have; a behaviour- or cost-changing parameter missing from the skill that covers it (`must_document`) |
 | Defaults | A documented default that contradicts the server's schema |
-| CLI claims | A "no CLI command for X" line that is no longer true, and any `sonilo <subcommand>` that does not exist |
+| CLI claims | A "no CLI command for X" line that is no longer true; any `sonilo <subcommand>` that does not exist; any **option** passed to one that does not exist; a skill that routes to the CLI without showing a command to run |
 | Banned tokens | Strings that were true once — see `banned_tokens` in `tool_surface.json` |
 
 ## Keeping it honest
@@ -35,3 +35,10 @@ out the hard way.
 
 When a check needs to change, change the check — and add the case that would
 have caught the bug you just fixed by hand.
+
+The flag check exists for that reason: writing the transport blocks, an
+`--async` flag was invented for `sonilo dubbing`, which has always been async
+and never had one. The subcommand was real, so nothing failed. Its first
+negative test then found two bugs in the checks themselves — the command anchor
+skipped anything inside a blockquote, and the transport check was satisfied by
+any tool name the prose happened to mention. Run the negative test.

--- a/tests/tool_surface.json
+++ b/tests/tool_surface.json
@@ -242,6 +242,141 @@
     "no_command": {
       "_comment": "Tools with genuinely no CLI equivalent. Saying so is allowed only for these.",
       "play_audio": true
+    },
+    "flags": {
+      "_comment": [
+        "Options per subcommand, parsed from `sonilo --help` on the published CLI.",
+        "Recorded after an `--async` flag that does not exist was written into a",
+        "skill: subcommands were checkable, the flags passed to them were not.",
+        "Includes the few documented inline in the Commands block (usage --days,",
+        "tasks wait --poll-interval/--timeout) as well as the per-command sections."
+      ],
+      "global": [
+        "--api-key",
+        "--help",
+        "--version"
+      ],
+      "per_command": {
+        "account": [],
+        "audio-ducking": [
+          "--music",
+          "--music-url",
+          "--output",
+          "--voice",
+          "--voice-url"
+        ],
+        "dubbing": [
+          "--ducking",
+          "--languages",
+          "--output",
+          "--timeout",
+          "--video",
+          "--video-url"
+        ],
+        "login": [
+          "--api-base",
+          "--force",
+          "--no-browser"
+        ],
+        "logout": [
+          "--api-base",
+          "--local-only"
+        ],
+        "tasks": [
+          "--poll-interval",
+          "--timeout"
+        ],
+        "text-to-music": [
+          "--async",
+          "--duration",
+          "--format",
+          "--output",
+          "--prompt",
+          "--segments",
+          "--variants"
+        ],
+        "text-to-sfx": [
+          "--duration",
+          "--format",
+          "--output",
+          "--prompt"
+        ],
+        "usage": [
+          "--days"
+        ],
+        "video-to-music": [
+          "--async",
+          "--format",
+          "--isolate-vocals",
+          "--output",
+          "--preserve-speech",
+          "--prompt",
+          "--prompt-influence",
+          "--segments",
+          "--variants",
+          "--video",
+          "--video-url"
+        ],
+        "video-to-sfx": [
+          "--format",
+          "--output",
+          "--prompt",
+          "--segments",
+          "--video",
+          "--video-url"
+        ],
+        "video-to-sound": [
+          "--ducking",
+          "--keep-original-sound",
+          "--music-prompt",
+          "--no-ducking",
+          "--output",
+          "--preserve-speech",
+          "--segments",
+          "--sfx-prompt",
+          "--stem",
+          "--variants",
+          "--video",
+          "--video-url"
+        ],
+        "video-to-video-music": [
+          "--ducking",
+          "--isolate-vocals",
+          "--keep-original-sound",
+          "--no-ducking",
+          "--output",
+          "--preserve-speech",
+          "--prompt",
+          "--prompt-influence",
+          "--variants",
+          "--video",
+          "--video-url"
+        ],
+        "video-to-video-sfx": [
+          "--output",
+          "--prompt",
+          "--segments",
+          "--video",
+          "--video-url"
+        ],
+        "video-to-video-sound": [
+          "--ducking",
+          "--keep-original-sound",
+          "--music-prompt",
+          "--no-ducking",
+          "--output",
+          "--preserve-speech",
+          "--segments",
+          "--sfx-prompt",
+          "--stem",
+          "--variants",
+          "--video",
+          "--video-url"
+        ],
+        "whoami": [
+          "--api-base"
+        ]
+      }
     }
   },
   "defaults": {

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -220,6 +220,7 @@ def check_cli_claims(surface: dict, docs: dict[Path, str]) -> None:
     commands = set(cli["commands"])
     genuinely_absent = {k for k in cli["no_command"] if not k.startswith("_")}
     tool_to_command = cli["tool_to_command"]
+    flag_surface = cli.get("flags", {})
 
     for path, text in docs.items():
         rel = path.relative_to(ROOT)
@@ -235,6 +236,20 @@ def check_cli_claims(surface: dict, docs: dict[Path, str]) -> None:
                 fail(str(rel), f"claims `{tool}` has no CLI command, but "
                                f"`sonilo {tool_to_command[tool]}` exists")
 
+        # 1b. A skill that declares the CLI as a transport must have one. The
+        #     frontmatter promise and the tool-to-command map have to agree, or
+        #     an agent follows the routing block into a command that does not
+        #     exist for this tool.
+        if path.name == "SKILL.md" and "sonilo whoami" in text:
+            shows_a_command = re.search(
+                r"(?:^|\$ |`|>\s)\s*sonilo (?!whoami|login|logout)[a-z][a-z-]{2,}",
+                text, re.M)
+            if not shows_a_command:
+                absent = sorted(t for t in genuinely_absent if re.search(rf"\b{t}\b", text))
+                because = f" — {', '.join(absent)} has no CLI command" if absent else ""
+                fail(str(rel), "routes to the CLI but shows no `sonilo` command to "
+                               f"run{because}")
+
         # 2. Any `sonilo <subcommand>` shown must be a real subcommand. Only
         #    shell invocations count: `from sonilo import Sonilo` is Python, and
         #    matching it would report `import` as a missing subcommand in every
@@ -242,9 +257,29 @@ def check_cli_claims(surface: dict, docs: dict[Path, str]) -> None:
         for line in text.splitlines():
             if "import" in line:
                 continue
-            m = re.search(r"(?:^|\$ |`)sonilo ([a-z][a-z-]{2,})\b", line)
-            if m and m.group(1) not in commands:
-                fail(str(rel), f"shows `sonilo {m.group(1)}`, which is not a CLI subcommand")
+            # Leading `> `, indentation and list markers are all normal in
+            # these files; a command inside a blockquote is still a command.
+            m = re.search(r"(?:^|\$ |`|>\s|^\s*[-*]\s)\s*sonilo ([a-z][a-z-]{2,})\b",
+                          line.lstrip("> ").rstrip() if line.lstrip().startswith(">") else line)
+            if not m:
+                continue
+            sub = m.group(1)
+            if sub not in commands:
+                fail(str(rel), f"shows `sonilo {sub}`, which is not a CLI subcommand")
+                continue
+
+            # 3. And the options passed to it must exist. A subcommand that is
+            #    real with a flag that is not reads exactly as authoritative,
+            #    and `--async` on `sonilo dubbing` got written here that way:
+            #    the command has always been async, so the flag never existed.
+            known = set(flag_surface.get("global", []))
+            known |= set(flag_surface.get("per_command", {}).get(sub, []))
+            if not known:
+                continue
+            for flag in re.findall(r"(?<![\w-])(--[a-z][a-z-]+)", line[m.end():]):
+                if flag not in known:
+                    fail(str(rel), f"shows `sonilo {sub} {flag}`, which is not one "
+                                   f"of its options")
 
 
 def check_banned_tokens(surface: dict, docs: dict[Path, str]) -> None:

--- a/text-to-music/SKILL.md
+++ b/text-to-music/SKILL.md
@@ -2,7 +2,8 @@
 name: text-to-music
 description: Generate music from a text prompt using Sonilo — instrumental tracks, background beds, jingles, loops — when there is no video to score. Use when the user describes the music they want in words and gives a duration. Every track is licensed and cleared for commercial use. For scoring an existing video, use the video-to-music skill instead.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected and Sonilo credentials — either a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+compatibility: Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
 ---
 
 # Sonilo Text-to-Music
@@ -18,6 +19,15 @@ content, and advertising.
 > ⚠️ **Cost:** this tool makes an API call that may incur charges. Only call it when the user has actually asked for a generation. Check `get_account_services` (see the [account](../account) skill) if you're unsure whether free-trial runs remain.
 
 > **Scoring a video instead?** Use [video-to-music](../video-to-music) — it matches pacing, motion, and emotion to the actual cut, which a text prompt cannot do.
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`text_to_music` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
+2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start
 

--- a/text-to-sfx/SKILL.md
+++ b/text-to-sfx/SKILL.md
@@ -2,7 +2,8 @@
 name: text-to-sfx
 description: Generate a sound effect from a text description using Sonilo — a UI chime, a whoosh, an impact, ambience, a stylized cue — when there is no video to match. Use when the user describes the sound they want in words and gives a duration. For SFX matched to footage, use the video-to-sfx skill; for music, use text-to-music.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected and Sonilo credentials — either a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+compatibility: Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
 ---
 
 # Sonilo Text-to-SFX
@@ -17,6 +18,15 @@ the saved file.
 > ⚠️ **Cost:** this tool makes an API call that may incur charges. Only call it when explicitly requested.
 
 > **Matching sound to footage instead?** Use [video-to-sfx](../video-to-sfx) — it reads the cut and can pin sounds to specific moments, which a text prompt cannot do.
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`text_to_sfx` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
+2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start
 

--- a/video-to-music/SKILL.md
+++ b/video-to-music/SKILL.md
@@ -2,7 +2,8 @@
 name: video-to-music
 description: Score a video with original music using Sonilo — the model watches the cut and matches pacing, motion, and emotion, returning either the audio or a new video with the score muxed in. Use when the user has a finished video that needs a soundtrack. Every track is licensed and cleared for commercial use. For music with no video, use the text-to-music skill.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected and Sonilo credentials — either a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+compatibility: Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
 ---
 
 # Sonilo Video-to-Music
@@ -16,6 +17,15 @@ commercial use on social, brand content, and advertising.
 > **Setup:** See the [setup-api-key](../setup-api-key) skill to connect the Sonilo MCP server and authenticate — `sonilo login` (no key) or `SONILO_API_KEY`.
 
 > ⚠️ **Cost:** every tool below makes an API call that may incur charges. Only call it when the user has actually asked for a generation. Check `get_account_services` (see the [account](../account) skill) if you're unsure whether free-trial runs remain.
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`video_to_music` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
+2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start
 

--- a/video-to-sfx/SKILL.md
+++ b/video-to-sfx/SKILL.md
@@ -2,7 +2,8 @@
 name: video-to-sfx
 description: Generate sound effects matched to a video using Sonilo — footsteps, impacts, ambience, foley — optionally scripted to specific timed segments, returning either the audio or a new video with the SFX muxed in. Use when the user has footage that needs sound design. For SFX from a text description alone, use the text-to-sfx skill; for music, use video-to-music.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected and Sonilo credentials — either a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+compatibility: Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
 ---
 
 # Sonilo Video-to-SFX
@@ -15,6 +16,15 @@ task on the backend; the tools poll internally and hand back the saved file.
 > **Setup:** See the [setup-api-key](../setup-api-key) skill.
 
 > ⚠️ **Cost:** every tool below makes an API call that may incur charges. Only call it when explicitly requested.
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`video_to_sfx` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
+2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start
 

--- a/video-to-sound/SKILL.md
+++ b/video-to-sound/SKILL.md
@@ -2,7 +2,8 @@
 name: video-to-sound
 description: Generate music AND sound effects for a video in a single balanced, single-charge call using Sonilo. Use instead of calling the music and sound-effects skills separately for the same video — the two layers are mixed and ducked against each other by the backend. Returns a mixed audio track, or a new video with it muxed in.
 license: MIT
-compatibility: Requires the Sonilo MCP server connected and Sonilo credentials — either a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+compatibility: Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill.
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
 ---
 
 # Sonilo Video-to-Sound (Music + SFX Combined)
@@ -12,6 +13,15 @@ Generate a music bed and sound effects for a video in one call, balanced against
 > **Setup:** See the [setup-api-key](../setup-api-key) skill.
 
 > ⚠️ **Cost:** makes one API call that may incur charges (billed once, not twice, even though it produces both layers). Only call when explicitly requested.
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`video_to_sound` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
+2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start
 


### PR DESCRIPTION
Every skill already printed CLI commands, but nothing let an agent run one. The frontmatter said the MCP server was **required**, no skill said what to do when those tools are absent, and `setup-api-key`'s Step 0 probed only MCP before declaring "nothing is connected". A machine with the CLI installed and signed in got sent off to configure MCP it did not need, and the CLI sections were reference material rather than a path.

This is what makes "supports both, MCP preferred" a true statement rather than a marketing one.

## The routing

Each skill now carries a Transport block with a deterministic order:

1. **Sonilo MCP tools visible in this session** → use them. Preferred: no shell required, and the only transport that survives a dubbing job's two-hour poll.
2. **No MCP tools, but `sonilo whoami` exits 0** → use the CLI. Same API, same account, same credential file.
3. **Neither** → run `setup-api-key`. And do not curl the API to route around it: both transports handle uploads, polling and retries that a bare request does not.

Pick one at session start, do not mix. The shape is borrowed from [heygen-com/skills](https://github.com/heygen-com/skills/blob/master/heygen-video/SKILL.md), which does the same thing with a richer decision tree because their two paths bill differently. Ours is simpler: both of ours bill identically, so the presence of an API key says nothing about which transport the user wants.

The block lives in each `SKILL.md` rather than a shared reference, for the same reason the `must_document` check is per-skill: an agent reads the skill it was routed to and may open nothing else.

Also adds `allowed-tools: Bash, Read, Write, mcp__sonilo__*`, so a host that honours the field grants both surfaces together.

## The two exceptions, both stated in place

- **audio-playback** is MCP-only and says so. `play_audio` exists as an MCP tool and nothing else. With `audio-ducking` shipping in `sonilo-cli` 0.13.0 / 0.12.0, it is now the *only* one: the CLI covers 13 of 14 tools.
- **auto-dubbing** carries the opposite warning. On the CLI path the call cannot be one command — the backend polls up to two hours while a host's shell tool is capped far below that (ten minutes in Claude Code), so a foreground `sonilo dubbing` is killed with the job still running and already charged. It submits, then polls with `sonilo tasks wait`.

## Two new checks, and why

Writing this produced exactly the bug they catch: an `--async` flag was invented for `sonilo dubbing`, which has always been async and never had one. The subcommand was real, so the existing check passed it.

- **Options are now recorded per subcommand** (parsed from `sonilo --help` on the published CLI, including the few documented inline in the Commands block) and validated.
- **A skill that routes to the CLI must show a `sonilo` command**, so an MCP-only skill cannot claim the transport.

Their own negative test then found two bugs in the checks themselves, both fixed and re-tested:

- the command anchor skipped anything inside a blockquote — which is exactly where the bad flag sat;
- the transport check was satisfied by any tool name the prose happened to mention, and `audio-playback` mentions `text_to_music` in passing, so it would have passed while claiming a transport it does not have.

`python tests/validate.py` passes: 16 files, 11 skills, 13 hosted tools, 14 local tools.