### PR TITLE
Probe the transport with `sonilo account`, not `sonilo whoami`

### DIFF
--- a/account/SKILL.md
+++ b/account/SKILL.md
@@ -17,8 +17,8 @@ Two free, read-only tools for checking what a Sonilo account can do and how much
 Pick one at the start of the session and stay on it. Do not mix the two inside
 a single job, and do not announce the choice.
 
-1. **Sonilo MCP tools visible in this session** (`get_account_services` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
-2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+1. **Sonilo MCP tools visible in this session** (`get_account_services` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
 3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start

--- a/audio-ducking/SKILL.md
+++ b/audio-ducking/SKILL.md
@@ -19,8 +19,8 @@ Automatically duck a music bed under a voice track: Sonilo lowers the music wher
 Pick one at the start of the session and stay on it. Do not mix the two inside
 a single job, and do not announce the choice.
 
-1. **Sonilo MCP tools visible in this session** (`audio_ducking` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
-2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+1. **Sonilo MCP tools visible in this session** (`audio_ducking` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
 3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start

--- a/auto-dubbing/SKILL.md
+++ b/auto-dubbing/SKILL.md
@@ -21,8 +21,8 @@ Dub a video into one or more other languages: the speech is translated and re-vo
 Pick one at the start of the session and stay on it. Do not mix the two inside
 a single job, and do not announce the choice.
 
-1. **Sonilo MCP tools visible in this session** (`dubbing` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
-2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+1. **Sonilo MCP tools visible in this session** (`dubbing` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
 3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 > ⏱ **On the CLI path this call cannot be one command.** The backend polls for

--- a/setup-api-key/SKILL.md
+++ b/setup-api-key/SKILL.md
@@ -30,7 +30,7 @@ There are two transports, and either one is enough. Probe both before
 concluding that nothing is set up.
 
 1. **MCP:** is a `sonilo` MCP server connected (any Sonilo tool, e.g. `text_to_music` or `get_account_services`, available to call)? If so, call the free, read-only `get_account_services()`.
-2. **CLI:** if there are no Sonilo tools, run `sonilo whoami`. Exit code 0 means the CLI is installed and signed in, and the skills can drive it directly. Confirm with `sonilo account`, which is the same free call.
+2. **CLI:** if there are no Sonilo tools, run `sonilo account` — the same free, read-only call as above. Exit code 0 means the CLI is installed, signed in, and reaching the API, and the skills can drive it directly. **Do not probe with `sonilo whoami`:** it exits 0 even when signed out, so it cannot separate the two states, and on an account with no display name it prints an empty `account:` line that reads like a broken credential. It is worth running only to *show* which account is active, never to decide.
 3. **Either one succeeds:** Sonilo is configured and working. Say so and stop. Ask only whether they want to rotate credentials.
 4. **Fails with 401:** authentication is stale, not missing. If they signed in with `sonilo login`, the key may have expired (90 days) or been revoked — `sonilo login` again fixes it. Otherwise the key is wrong: continue at Path C.
 5. **Neither responds:** nothing is connected — pick a path below and run it. MCP is the better default (it needs no shell, and it is the only transport that survives a dubbing job's two-hour poll), but a CLI that is installed and signed in is a complete setup on its own; do not make someone configure MCP they will not use.

--- a/task-recovery/SKILL.md
+++ b/task-recovery/SKILL.md
@@ -19,8 +19,8 @@ Every Sonilo generation that runs asynchronously on the backend (SFX, ducking, v
 Pick one at the start of the session and stay on it. Do not mix the two inside
 a single job, and do not announce the choice.
 
-1. **Sonilo MCP tools visible in this session** (`get_sfx_task` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
-2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+1. **Sonilo MCP tools visible in this session** (`get_sfx_task` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
 3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start

--- a/text-to-music/SKILL.md
+++ b/text-to-music/SKILL.md
@@ -25,8 +25,8 @@ content, and advertising.
 Pick one at the start of the session and stay on it. Do not mix the two inside
 a single job, and do not announce the choice.
 
-1. **Sonilo MCP tools visible in this session** (`text_to_music` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
-2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+1. **Sonilo MCP tools visible in this session** (`text_to_music` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
 3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start

--- a/text-to-sfx/SKILL.md
+++ b/text-to-sfx/SKILL.md
@@ -24,8 +24,8 @@ the saved file.
 Pick one at the start of the session and stay on it. Do not mix the two inside
 a single job, and do not announce the choice.
 
-1. **Sonilo MCP tools visible in this session** (`text_to_sfx` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
-2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+1. **Sonilo MCP tools visible in this session** (`text_to_sfx` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
 3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start

--- a/video-to-music/SKILL.md
+++ b/video-to-music/SKILL.md
@@ -23,8 +23,8 @@ commercial use on social, brand content, and advertising.
 Pick one at the start of the session and stay on it. Do not mix the two inside
 a single job, and do not announce the choice.
 
-1. **Sonilo MCP tools visible in this session** (`video_to_music` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
-2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+1. **Sonilo MCP tools visible in this session** (`video_to_music` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
 3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start

--- a/video-to-sfx/SKILL.md
+++ b/video-to-sfx/SKILL.md
@@ -22,8 +22,8 @@ task on the backend; the tools poll internally and hand back the saved file.
 Pick one at the start of the session and stay on it. Do not mix the two inside
 a single job, and do not announce the choice.
 
-1. **Sonilo MCP tools visible in this session** (`video_to_sfx` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
-2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+1. **Sonilo MCP tools visible in this session** (`video_to_sfx` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
 3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start

--- a/video-to-sound/SKILL.md
+++ b/video-to-sound/SKILL.md
@@ -19,8 +19,8 @@ Generate a music bed and sound effects for a video in one call, balanced against
 Pick one at the start of the session and stay on it. Do not mix the two inside
 a single job, and do not announce the choice.
 
-1. **Sonilo MCP tools visible in this session** (`video_to_sound` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation.
-2. **No Sonilo MCP tools, but `sonilo whoami` exits 0** — use the CLI commands below. Same API, same account, same credential file.
+1. **Sonilo MCP tools visible in this session** (`video_to_sound` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
 3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
 
 ## Quick Start


### PR DESCRIPTION
Follow-up to #9, which put the MCP-or-CLI routing into 10 SKILL.md files. Testing that routing end to end found the CLI branch is gated on a probe that cannot fail.

## Step 2 was unreachable-proof

The rule was "`sonilo whoami` exits 0 → use the CLI". It always exits 0:

```console
$ sonilo whoami; echo $?        # signed out
Not signed in. Run sonilo login.
0
```

| | signed in | signed out |
|---|---|---|
| `sonilo whoami` | 0 | **0** |
| `sonilo account` | 0 | 1 |

So the condition is true regardless, step 3 (stop and run setup-api-key) was unreachable, and a user with no credential got routed to CLI commands that could only fail on auth.

`sonilo account` is the same free, read-only call, and it distinguishes the two states. It also proves the API is reachable rather than merely that a file exists on disk. The reason is written into the line itself so the shorter-looking command does not get restored later.

## Step 1 gains a fall-through

"Visible" and "usable" are not the same thing. The hosted MCP server needs an OAuth grant a headless session cannot complete; an agent that found the tools listed but unusable stopped there instead of dropping to the CLI, which was authenticated the whole time. An **authentication** failure now means the transport is unavailable and step 2 applies. An **input** error still does not — that is a bad call, not a bad transport.

## Evidence, at its real strength

The exit-code defect is proven from a shell in one command and needs no behavioural argument: a probe returning 0 in both states carries no information by construction.

The behavioural side is weaker than it first appeared, and I want that on the record rather than buried. With both probe commands permitted and everything else held constant (same prompt, same model, same flags), the old text elicited `sonilo whoami` in **1 of 3** runs and the new text in **0 of 3**. That is directional, not conclusive — n=3 per arm.

An earlier reading of "reproduced 2/2" was wrong: one of those two runs had failed because Bash was not permitted in that non-interactive session, not because of the probe. That correction has also been applied to the linked CLI PR.

## Related

sonilo-ai/sonilo-js#53 fixes `whoami` itself — non-zero when signed out, and the account id shown where a whitespace-only `account_name` printed a blank line that reads exactly like a credential that never loaded. That blank line is what made one agent judge an authenticated CLI to be unconfigured.

These two changes are independent on purpose: the skills should not depend on users having a CLI new enough to carry the fix, and `sonilo account` is a correct probe on every released version.

## Verification

`tests/validate.py` passes (16 files, 11 skills). Ten SKILL.md files updated — the nine that share the routing block, plus setup-api-key's Step 0 variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)