### PR TITLE
Fix skill repo review findings

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,8 +20,12 @@ jobs:
         with:
           python-version: "3.12"
 
-      # The offline checks are stdlib-only on purpose: frontmatter, tool names,
-      # parameters, defaults and banned tokens all validate with no install.
+      - name: Install validator dependencies
+        run: python -m pip install PyYAML
+
+      # The offline checks need PyYAML only so frontmatter is parsed as real
+      # YAML. Tool names, parameters, defaults and banned tokens validate
+      # against the recorded surface with no Sonilo install.
       - name: Validate skills against the recorded tool surface
         run: python tests/validate.py
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npx skills add sonilo-ai/skills
 Or install a single skill:
 
 ```bash
-npx skills add sonilo-ai/skills/video-to-music
+npx skills add sonilo-ai/skills --skill video-to-music
 ```
 
 ### Option 2: Claude Code plugin
@@ -135,11 +135,11 @@ billing twice for the two separate skills.
 claude plugin eval skills@sonilo-skills
 ```
 
-`claude plugin eval` is in early access and does not run yet; the cases are
-schema-valid and their assumptions verified headlessly. See
-[evals/README.md](./evals/README.md) for what was checked and how. Functional
-evals — does the call produce correct audio — are still open; contributions
-welcome.
+`claude plugin eval` is still early-access gated as of Claude Code 2.1.232, so
+these cases are schema-valid but not yet runnable by every CLI install. They are
+routing-only and cannot call Sonilo generation tools. See
+[evals/README.md](./evals/README.md) for the current status. Functional evals —
+does the call produce correct audio — are still open; contributions welcome.
 
 ## License
 

--- a/auto-dubbing/SKILL.md
+++ b/auto-dubbing/SKILL.md
@@ -32,10 +32,10 @@ a single job, and do not announce the choice.
 > separately instead:
 >
 > ```bash
-> # --timeout is the CLI's own wait, not the job's: it returns early and the
-> # task keeps running. The id comes from the "Submitted task ..." line.
-> sonilo dubbing --video-url https://example.com/clip.mp4 --languages es,fr --timeout 300000
-> sonilo tasks wait <task-id> --timeout 300000   # repeat until it finishes
+> # --timeout is the CLI's own wait, not the job's: this returns before a host
+> # shell can kill the process. The id comes from the "Submitted task ..." line.
+> sonilo dubbing --video-url https://example.com/clip.mp4 --languages es,fr --timeout 300
+> sonilo tasks wait <task-id>   # repeat until it finishes
 > ```
 >
 > The MCP path has no such limit and is the better transport for dubbing.
@@ -90,7 +90,7 @@ sonilo dubbing --video-url https://example.com/product-demo.mp4 --languages es,f
 # writes dubbed.es.mp4 and dubbed.fr.mp4
 ```
 
-`--timeout` defaults to 7200 seconds already, matching the backend's ceiling — no need to override it for a typical call.
+`--timeout` defaults to 7200 seconds already, matching the backend's ceiling. That is fine in a normal terminal; inside an agent host shell, use the shorter submit-and-poll pattern above so the shell tool does not kill the foreground command.
 
 ### cURL (raw REST API, no MCP host)
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -23,17 +23,19 @@ separately bills the user twice for what `video_to_sound` does in one charge.
 
 ```bash
 claude plugin eval skills@sonilo-skills          # or a path, or plugin@marketplace
-claude plugin eval . --case 'routing-*' --runs 3
+claude plugin eval . --case 'routing-*' --runs 3 --no-publish
 ```
 
-**`claude plugin eval` is in early access and refuses to run as of CLI 2.1.231**,
-so these cases are schema-valid but have not been executed by the harness. What
-*has* been verified is every assumption they rest on:
+As of Claude Code 2.1.232, `claude plugin eval --help` documents the command,
+but running it still exits with `` `plugin eval` is currently in early access ``.
+These cases are schema-valid but have not been executed by the eval harness.
+They are safe to run as routing checks once the gate opens because they allow
+only the `Skill` tool. The schema and grader assumptions are:
 
-- The schema itself is transcribed from the CLI's own validator in 2.1.231
+- The cases use `schema_version` 1.1 with grader types
   (`schema_version` 1.1; grader types `regex`, `tool_order`, `tool_used`,
-  `file_exists`, `llm`, `baseline`), because the format is not yet documented
-  publicly. Re-check it when the feature ships.
+  `file_exists`, `llm`, `baseline`). Re-check them against the eval runner once
+  access is available.
 - `tool_used` compares the tool name exactly and tests `input_match` as a JS
   RegExp against the serialized tool input.
 - A skill invocation records as tool `Skill` with input

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,6 +8,7 @@ behaviour-changing parameters documented nowhere, a `ducking` default that had
 been flipped upstream a release earlier, and a key prefix that was never right. The CLI check was added after six "no CLI command for video_to_video_*" lines outlived the release that added both commands and then survived a full repo restructure by moving to new files.
 
 ```bash
+python -m pip install PyYAML         # validator dependency
 python tests/validate.py             # offline; what CI runs on every push
 python tests/validate.py --refresh   # needs `pip install sonilo-mcp`; re-reads
                                      # the local tool surface from the package
@@ -17,7 +18,7 @@ python tests/validate.py --refresh   # needs `pip install sonilo-mcp`; re-reads
 
 | Check | Catches |
 |---|---|
-| Frontmatter | `name` not matching the directory (installed copies resolve by name), missing fields, a description over the spec's 1024 chars or one that never says "Sonilo" and so never routes |
+| Frontmatter | Invalid YAML, `name` not matching the directory (installed copies resolve by name), missing fields, a description over the spec's 1024 chars or one that never says "Sonilo" and so never routes |
 | Tool names | A tool that exists on neither server; naming `get_sfx_task` without `get_generation_task` (or the reverse) — the two servers use different names for the same tool, so a doc that knows only one breaks for half the users |
 | Parameters | A parameter passed in an example that the tool does not have; a behaviour- or cost-changing parameter missing from the skill that covers it (`must_document`) |
 | Defaults | A documented default that contradicts the server's schema |

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -23,7 +23,8 @@ What it checks:
 Run: python tests/validate.py            # offline, this is what CI runs
      python tests/validate.py --refresh  # regenerate the local surface from an
                                          # installed sonilo-mcp, then check
-Stdlib only, on purpose: CI needs no install step to run the offline checks.
+Requires PyYAML so the frontmatter is parsed exactly as YAML, not approximated
+with a line scanner.
 """
 from __future__ import annotations
 
@@ -31,6 +32,12 @@ import json
 import re
 import sys
 from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised by environments, not tests
+    print("tests/validate.py needs PyYAML: python -m pip install PyYAML", file=sys.stderr)
+    raise SystemExit(2)
 
 ROOT = Path(__file__).resolve().parent.parent
 SURFACE = Path(__file__).resolve().parent / "tool_surface.json"
@@ -49,9 +56,7 @@ def note(message: str) -> None:
 
 
 def parse_frontmatter(text: str, where: str) -> dict:
-    """Read the leading `---` block. Deliberately not a YAML parser: these files
-    are flat `key: value` pairs and a dependency-free CI is worth more than
-    supporting nesting nobody uses."""
+    """Read and validate the leading YAML frontmatter block."""
     if not text.startswith("---\n"):
         fail(where, "no frontmatter block")
         return {}
@@ -59,20 +64,19 @@ def parse_frontmatter(text: str, where: str) -> dict:
     if end == -1:
         fail(where, "frontmatter block is never closed")
         return {}
-    out: dict[str, str] = {}
-    key = None
-    for lineno, line in enumerate(text[4:end].splitlines(), start=2):
-        m = re.match(r"^([a-zA-Z_-]+):\s*(.*)$", line)
-        if m:
-            key = m.group(1)
-            value = m.group(2).strip()
-            if value and not value.startswith(("'", '"', "|", ">")) and re.search(r":(?:\s|$)", value):
-                fail(where, f"frontmatter line {lineno} has an unquoted `: ` in `{key}`; "
-                            "quote the value or use a folded block")
-            out[key] = value
-        elif key and line.startswith((" ", "\t")):
-            out[key] += " " + line.strip()  # folded continuation
-    return out
+    block = text[4:end]
+    try:
+        parsed = yaml.safe_load(block) or {}
+    except yaml.YAMLError as exc:
+        detail = getattr(exc, "problem", None) or str(exc).splitlines()[0]
+        mark = getattr(exc, "problem_mark", None)
+        location = f" at line {mark.line + 1} column {mark.column + 1}" if mark else ""
+        fail(where, f"invalid YAML frontmatter{location}: {detail}")
+        return {}
+    if not isinstance(parsed, dict):
+        fail(where, "frontmatter must be a YAML mapping")
+        return {}
+    return {str(key): "" if value is None else str(value) for key, value in parsed.items()}
 
 
 def check_frontmatter(skill_dir: Path, text: str) -> None:


### PR DESCRIPTION
## What changed
- Parse skill frontmatter with PyYAML in `tests/validate.py` and install PyYAML in CI.
- Update README single-skill install command to use `--skill`.
- Update eval docs to reflect Claude Code 2.1.232 behavior: `plugin eval` is documented but still early-access gated at runtime.
- Clarify `auto-dubbing` CLI timeout guidance for normal terminals vs agent host shells.

## Validation
- `python3 tests/validate.py`
- YAML parse of workflow, eval cases, and every `*/SKILL.md` frontmatter
- `claude plugin validate --strict .claude-plugin/plugin.json`
- `claude plugin validate --strict .claude-plugin/marketplace.json`
- Markdown local-link check
- `git diff --check`

Note: a smoke run of `claude plugin eval . --case routing-video-scoring --runs 1 --no-publish ...` still exits with `plugin eval is currently in early access`, which is now documented.