### PR TITLE
feat: video-analysis skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skills",
   "displayName": "Sonilo Skills",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Agent Skills for Sonilo's licensed music, sound-effects, dubbing, and audio-ducking API \u2014 with structured-brief prompting guidance (pre-flight, music briefs, SFX action maps) folded into each skill.",
   "author": {
     "name": "Sonilo AI",
@@ -22,7 +22,8 @@
     "text-to-music",
     "video-to-sfx",
     "text-to-sfx",
-    "auto-dubbing"
+    "auto-dubbing",
+    "video-analysis"
   ],
   "skills": [
     "./video-to-music",
@@ -30,6 +31,7 @@
     "./video-to-sfx",
     "./text-to-sfx",
     "./video-to-sound",
+    "./video-analysis",
     "./audio-ducking",
     "./auto-dubbing",
     "./task-recovery",

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npx skills add sonilo-ai/skills --skill video-to-music
 /plugin install skills@sonilo-skills
 ```
 
-This installs the same eleven skills (`video-to-music`, `text-to-music`, `video-to-sfx`, `text-to-sfx`, `video-to-sound`, `audio-ducking`, `auto-dubbing`, `task-recovery`, `account`, `audio-playback`, `setup-api-key`) as a single Claude Code plugin, discovered directly from their existing top-level directories — no separate copy to keep in sync. It's a skills-only plugin (no MCP server, no bundled tools); see [Configuration](#configuration) below for how to connect the Sonilo MCP server itself.
+This installs the same twelve skills (`video-to-music`, `text-to-music`, `video-to-sfx`, `text-to-sfx`, `video-to-sound`, `video-analysis`, `audio-ducking`, `auto-dubbing`, `task-recovery`, `account`, `audio-playback`, `setup-api-key`) as a single Claude Code plugin, discovered directly from their existing top-level directories — no separate copy to keep in sync. It's a skills-only plugin (no MCP server, no bundled tools); see [Configuration](#configuration) below for how to connect the Sonilo MCP server itself.
 
 ## Available Skills
 
@@ -40,6 +40,7 @@ This installs the same eleven skills (`video-to-music`, `text-to-music`, `video-
 | [video-to-sfx](./video-to-sfx) | Generate sound effects matched to a video, with optional timed segments (`video_to_sfx`, `video_to_video_sfx`) |
 | [text-to-sfx](./text-to-sfx) | Generate one sound effect from a text description alone (`text_to_sfx`) |
 | [video-to-sound](./video-to-sound) | Generate music **and** SFX for a video in one balanced, single-charge call (`video_to_sound`, `video_to_video_sound`) |
+| [video-analysis](./video-analysis) | Analyze a video and get a creative brief — section plan plus ready-to-use generation prompts — instead of a track (`analyze_video`) |
 | [audio-ducking](./audio-ducking) | Duck a music bed under a voice track (or a video's voice track) automatically (`audio_ducking`) |
 | [auto-dubbing](./auto-dubbing) | Dub a video into other languages with re-voiced speech (`dubbing`) |
 | [task-recovery](./task-recovery) | Recover the result of a timed-out generation using its task id (`get_sfx_task`, or `get_generation_task` on the hosted server) |

--- a/references/api-claims.md
+++ b/references/api-claims.md
@@ -22,6 +22,21 @@ Every numeric limit and behavior claim used by the skills in this repo, verified
 - [x] Exclusions — global prompt or segment prompts, both verbatim free text, **best-effort**.
 - [x] Timestamps — sub-second floats passed upstream **as-is, no rounding** (⚠️ unlike music segments which round to whole seconds — don't conflate).
 
+## video_analysis
+
+Added 2026-08-16 with the endpoint itself; verified against the shipped backend and the live
+`platform.sonilo.com/openapi.json`, not against an engineering conversation.
+
+- [x] **Cap 600 s** — the most generous cap of any endpoint (music is 360 s, SFX/sound/dubbing 180 s). A video can be analyzable and still too long to score in one call. Over-cap = **422 reject**.
+- [x] **Generates nothing.** No audio, no video, no artifact. The result is `segments` (whole-second `start`/`end`, a `label`, and a per-stretch `prompt`) plus `variations` (one generation `prompt` each). This is the only Sonilo task type with no media in its envelope, which is why every client surfaces it as text rather than a saved file.
+- [x] `variants_num` **1-5**, billed per brief — narrower than the music endpoints' 1-10. `prompt` ≤ 2000 chars, and it steers the **analysis**, not the score.
+- [x] **10-second billing floor**: a fixed per-request output cost regardless of clip length, so a 3-second clip costs the same as a 10-second one.
+- [x] Free trial: 2 calls, self-serve accounts only (the platform default allowance).
+- [x] Async, worker-executed: `202` + `task_id`, result on `GET /v1/tasks/{id}`. Failure carries `error.code` `ANALYSIS_FAILED` and is refunded; `TRANSFER_FAILED`, `INVALID_PAYLOAD` and `GENERATION_FAILED` are also possible depending on where it broke.
+- [x] `503 "Video analysis is temporarily unavailable"` is a server-side kill switch (`PROMPT_SERVICE_ENABLED`), not an auth or balance problem. No retry loop fixes it.
+- [x] The variation prompts are **narrower than what the upstream produces** by product decision: `negative_prompt`, `thinking`, `structure_source` and the variation title/summary/tags are stripped before the envelope is built and are not recoverable from the task.
+- [x] ⚠️ **Input differs by MCP server**: the hosted server exposes `video_url` only; local `sonilo-mcp` (0.17.0+) also takes `video_path`. Both SDKs and both CLIs accept a local file or a URL.
+
 ## Billing / general
 
 - [x] Charged up front at submission; **failed generations auto-refunded**. Caller retries = new charge. **No preview/low-cost mode.** Music + SFX = separate task types, separate per-second rates, separate prepay minute pools. `variants_num` scales v2m cost linearly; N>1 never covered by free trial.
@@ -38,5 +53,5 @@ Every numeric limit and behavior claim used by the skills in this repo, verified
 
 ## Live spec observations (sonilo.com/openapi.json, 2026-07-29)
 
-- Public endpoints (re-verified 2026-08-12 against `platform.sonilo.com/openapi.json`): `/v1/account/services` · `/v1/account/usage` · `/v1/text-to-music` · `/v1/text-to-sfx` · `/v1/video-to-music` · `/v1/video-to-sfx` · `/v1/video-to-video-music` · `/v1/video-to-video-sfx` · `/v1/video-to-sound` · `/v1/video-to-video-sound` · `/v1/audio-ducking` · `/v1/dubbing` · `/v1/tasks/{task_id}`. ⚠️ Corrects the 2026-07-29 observation this replaces: a combined music+SFX endpoint now exists (`/v1/video-to-sound` for audio-only output, `/v1/video-to-video-sound` for video output), and video-out endpoints are in the public spec (`/v1/video-to-video-music`, `/v1/video-to-video-sfx`, `/v1/video-to-video-sound`) — consistent with line 32's MCP claim above. Dubbing (`/v1/dubbing`) also shipped since the earlier pass.
+- Public endpoints (re-verified 2026-08-12 against `platform.sonilo.com/openapi.json`): `/v1/account/services` · `/v1/account/usage` · `/v1/text-to-music` · `/v1/text-to-sfx` · `/v1/video-to-music` · `/v1/video-to-sfx` · `/v1/video-to-video-music` · `/v1/video-to-video-sfx` · `/v1/video-to-sound` · `/v1/video-to-video-sound` · `/v1/audio-ducking` · `/v1/dubbing` · `/v1/video-analysis` (added 2026-08-16) · `/v1/tasks/{task_id}`. ⚠️ Corrects the 2026-07-29 observation this replaces: a combined music+SFX endpoint now exists (`/v1/video-to-sound` for audio-only output, `/v1/video-to-video-sound` for video output), and video-out endpoints are in the public spec (`/v1/video-to-video-music`, `/v1/video-to-video-sfx`, `/v1/video-to-video-sound`) — consistent with line 32's MCP claim above. Dubbing (`/v1/dubbing`) also shipped since the earlier pass.
 - `VideoToMusicRequest` confirms REST `segments` param exists; also has `isolate_vocals` — **behavior unverified, not yet covered by the skills**.

--- a/task-recovery/SKILL.md
+++ b/task-recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-recovery
-description: Recover the result of a timed-out Sonilo generation call using its task_id. Use whenever text_to_sfx, video_to_sfx, video_to_video_music, video_to_video_sfx, video_to_sound, video_to_video_sound, audio_ducking, dubbing, or video_to_music(preserve_speech=true) times out or its call was interrupted — the generation already ran (and was already charged) and its result is still retrievable.
+description: Recover the result of a timed-out Sonilo generation call using its task_id. Use whenever text_to_sfx, video_to_sfx, video_to_video_music, video_to_video_sfx, video_to_sound, video_to_video_sound, audio_ducking, dubbing, analyze_video, or video_to_music(preserve_speech=true) times out or its call was interrupted — the generation already ran (and was already charged) and its result is still retrievable.
 license: MIT
 compatibility: "Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill."
 allowed-tools: Bash, Read, Write, mcp__sonilo__*
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Write, mcp__sonilo__*
 
 # Sonilo Task Recovery
 
-Every Sonilo generation that runs asynchronously on the backend (SFX, ducking, video-to-video, video-to-sound, dubbing, and `video_to_music(preserve_speech=true)`) is already charged the moment it's accepted — a client-side timeout does **not** stop it or refund it. This tool checks a task's status and, once finished, downloads its result. It never itself charges anything.
+Every Sonilo generation that runs asynchronously on the backend (SFX, ducking, video-to-video, video-to-sound, dubbing, video-analysis, and `video_to_music(preserve_speech=true)`) is already charged the moment it's accepted — a client-side timeout does **not** stop it or refund it. This tool checks a task's status and, once finished, downloads its result. It never itself charges anything.
 
 > **Setup:** See the [setup-api-key](../setup-api-key) skill.
 
@@ -49,7 +49,7 @@ result = client.tasks.wait("a1b2c3d4-...")  # polls until terminal; raises TaskF
 result.save("recovered.wav")
 ```
 
-`tasks.get`/`tasks.wait` default to parsing an SFX-shaped result. For a task from `dubbing`, `video_to_sound`/`video_to_video_sound`, or async `video_to_music`, pass the matching parser explicitly (`from sonilo.resources.tasks import parse_music_result, parse_sound_result, parse_dubbing_result`) — see [sonilo-python's README](https://github.com/sonilo-ai/sonilo-python#sound-effects-async-tasks) for the exact call shape per task type.
+`tasks.get`/`tasks.wait` default to parsing an SFX-shaped result. For a task from `dubbing`, `video_to_sound`/`video_to_video_sound`, `analyze_video`, or async `video_to_music`, pass the matching parser explicitly (`from sonilo.resources.tasks import parse_music_result, parse_sound_result, parse_dubbing_result, parse_video_analysis_result`) — see [sonilo-python's README](https://github.com/sonilo-ai/sonilo-python#sound-effects-async-tasks) for the exact call shape per task type.
 
 ### JavaScript / TypeScript (`npm install sonilo`)
 
@@ -98,7 +98,7 @@ The MCP tool does one status check and, if `status` is terminal, downloads and s
 | Status | What happens |
 |--------|--------------|
 | `processing` | Returns a "still processing, try again later" message. No file saved. Call again after a short wait. |
-| `succeeded` | Downloads and saves the result — audio for `text_to_sfx`/`video_to_sfx`; a single `.wav` or `.mp4` for `audio_ducking`; a single `.mp4` for `video_to_video_music`/`video_to_video_sfx`/`video_to_video_sound`; a single `.wav` for `video_to_sound`; one `.mp4` per language for `dubbing`; for a `video_to_music(preserve_speech=true)` task, the music stream(s) plus the `vocals` stem plus the `mux`. |
+| `succeeded` | Downloads and saves the result — audio for `text_to_sfx`/`video_to_sfx`; a single `.wav` or `.mp4` for `audio_ducking`; a single `.mp4` for `video_to_video_music`/`video_to_video_sfx`/`video_to_video_sound`; a single `.wav` for `video_to_sound`; one `.mp4` per language for `dubbing`; for a `video_to_music(preserve_speech=true)` task, the music stream(s) plus the `vocals` stem plus the `mux`. An `analyze_video` task is the exception: it has no file at all, so the creative brief comes back inline as JSON and nothing is written to disk. |
 | `failed` | Raises an error including the backend's error code/message and whether the charge was **refunded** — check this before telling the user they've been billed for nothing. |
 | task id not found (404) | The id is wrong/typo'd, or belongs to a purely streaming call (`text_to_music`, or `video_to_music` without `preserve_speech`/`ducking`/`output_format="wav"`) — those have no task at all and can't be recovered this way. Nothing to retry. |
 | any other status (not `processing`/`succeeded`/`failed`) | Raised as an "unexpected task status" error naming the task id. Treat as transient — this is a backend state this tool doesn't otherwise special-case — and call `get_sfx_task(task_id)` again shortly. |

--- a/tests/tool_surface.json
+++ b/tests/tool_surface.json
@@ -11,9 +11,9 @@
     "skill naming one must name the other too, or it breaks for half the users."
   ],
   "_generated": {
-    "local_from": "sonilo-mcp 0.16.0 (PyPI)",
+    "local_from": "sonilo-mcp 0.17.0 (PyPI)",
     "hosted_from": "sonilo-api-dashboard backend/app/mcp_server.py",
-    "date": "2026-08-12"
+    "date": "2026-08-16"
   },
   "hosted": {
     "get_account_services": [],
@@ -92,6 +92,11 @@
       "video_url",
       "languages",
       "ducking"
+    ],
+    "analyze_video": [
+      "video_url",
+      "prompt",
+      "variants_num"
     ]
   },
   "local": {
@@ -194,6 +199,12 @@
     ],
     "play_audio": [
       "input_file_path"
+    ],
+    "analyze_video": [
+      "video_path",
+      "video_url",
+      "prompt",
+      "variants_num"
     ]
   },
   "cli": {
@@ -221,7 +232,8 @@
       "video-to-video-sound",
       "audio-ducking",
       "dubbing",
-      "tasks"
+      "tasks",
+      "video-analysis"
     ],
     "tool_to_command": {
       "text_to_music": "text-to-music",
@@ -237,7 +249,8 @@
       "get_sfx_task": "tasks",
       "get_generation_task": "tasks",
       "get_account_services": "account",
-      "get_usage": "usage"
+      "get_usage": "usage",
+      "analyze_video": "video-analysis"
     },
     "no_command": {
       "_comment": "Tools with genuinely no CLI equivalent. Saying so is allowed only for these.",
@@ -303,6 +316,14 @@
         ],
         "usage": [
           "--days"
+        ],
+        "video-analysis": [
+          "--output",
+          "--prompt",
+          "--timeout",
+          "--variants",
+          "--video",
+          "--video-url"
         ],
         "video-to-music": [
           "--async",
@@ -418,6 +439,9 @@
     ],
     "video_to_sfx": [
       "segments"
+    ],
+    "analyze_video": [
+      "variants_num"
     ]
   },
   "banned_tokens": {

--- a/video-analysis/SKILL.md
+++ b/video-analysis/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: video-analysis
+description: Analyze a video with Sonilo and get back a creative brief for scoring it — a time-aligned section plan plus one or more ready-to-use generation prompts, derived from the footage itself. Use when the user has a video that needs sound but nobody knows yet what it should sound like, or when a first generation missed and you need a better prompt rather than another reroll. Generates no audio and no video; the output is text you feed into video-to-music, video-to-sfx, or video-to-sound.
+license: MIT
+compatibility: "Requires Sonilo through either transport — the MCP server connected, or the `sonilo` CLI installed and signed in — plus credentials: a `sonilo login` sign-in, the hosted OAuth plugin, or SONILO_API_KEY. See the setup-api-key skill."
+allowed-tools: Bash, Read, Write, mcp__sonilo__*
+---
+
+# Sonilo Video Analysis
+
+Hand Sonilo a video and it returns a **creative brief** for scoring it: a
+time-aligned `segments` plan (what each stretch of footage wants) plus one or
+more `variations`, each a single ready-to-use generation prompt.
+
+This skill **generates nothing**. No audio, no video, no file. Its whole
+output is text, and the text is the input to the next call.
+
+> **Setup:** See the [setup-api-key](../setup-api-key) skill to connect the Sonilo MCP server and authenticate — `sonilo login` (no key) or `SONILO_API_KEY`.
+
+> ⚠️ **Cost:** this is a paid call, even though nothing is generated. Billing has a 10-second floor and `variants_num` is billed per brief, so 3 variations cost 3×. Only call it when the user has actually asked. Check `get_account_services` (see the [account](../account) skill) if you're unsure whether free-trial runs remain.
+
+## When to reach for this
+
+Use it when:
+
+- **The user doesn't know what the video should sound like.** "Make this sound good" is not a prompt. Analyze first, show them the variations, let them pick.
+- **A first generation missed.** A bad result usually means a bad brief, not a bad model. Analyzing beats rerolling: a reroll is a fresh charge on the same weak prompt.
+- **The video has distinct sections** and you want them scored deliberately rather than as one continuous bed. `segments` gives you the section boundaries the footage actually has.
+
+Do **not** use it when the user already told you what they want. If they said
+"tense synths, drop at the 20-second mark", go straight to
+[video-to-music](../video-to-music) — analysis would just be an extra charge
+between them and their track.
+
+## Transport: MCP or CLI
+
+Pick one at the start of the session and stay on it. Do not mix the two inside
+a single job, and do not announce the choice.
+
+1. **Sonilo MCP tools visible in this session** (`analyze_video` and friends) — use them. This is the preferred path: it needs no shell, and it is the only one that survives a very long generation. If a call fails to authenticate — rather than failing on its inputs — this transport is not usable in this session: go to 2 instead of retrying it.
+2. **No usable Sonilo MCP tools, but `sonilo account` exits 0** — use the CLI commands below. Same API, same account, same credential file. Probe with `sonilo account`, not `sonilo whoami`: whoami exits 0 even when signed out, so it cannot tell the two states apart.
+3. **Neither** — stop and run the [setup-api-key](../setup-api-key) skill. Do not call `api.sonilo.com` with curl to work around it; both transports handle uploads, polling and retries that a bare request does not.
+
+### One difference between the two MCP servers
+
+`analyze_video` takes a **local file only on the local server**. The hosted
+(OAuth plugin) server is URL-only: it exposes `video_url` and nothing else. If
+the user's video is a local file and you are on the hosted server, use the CLI
+or an SDK instead of trying `video_path` — it is not a parameter there.
+
+## Quick Start
+
+### MCP tool call (recommended)
+
+```
+analyze_video(
+    video_path="~/Desktop/trailer.mp4",
+    prompt="focus on the chase",
+    variants_num=2
+)
+```
+
+Returns the brief inline as JSON. **Nothing is saved to disk** — unlike every
+other Sonilo tool, there is no output path, because there is no file.
+
+On the hosted server, pass `video_url` instead of `video_path`.
+
+### Python (`pip install sonilo`)
+
+```python
+from sonilo import Sonilo
+
+client = Sonilo()  # reads SONILO_API_KEY
+
+brief = client.video_analysis.analyze(
+    video="trailer.mp4",
+    prompt="focus on the chase",
+    variants_num=2,
+)
+
+for segment in brief.segments:
+    print(f"{segment.start}-{segment.end}s [{segment.label}] {segment.prompt}")
+
+# Feed a variation's prompt straight into a generation call.
+score = client.video_to_music.generate(
+    video="trailer.mp4", prompt=brief.variations[0].prompt
+)
+score.save("score.m4a")
+```
+
+The method is `analyze()`, not `generate()`, and the result has no `save()` —
+there is nothing to download.
+
+### JavaScript / TypeScript (`npm install sonilo`)
+
+```ts
+import { SoniloClient } from "sonilo";
+
+const client = new SoniloClient(); // reads SONILO_API_KEY
+
+const brief = await client.videoAnalysis.analyze({
+  video: "./trailer.mp4",
+  prompt: "focus on the chase",
+  variantsNum: 2,
+});
+
+const score = await client.videoToMusic.generate({
+  video: "./trailer.mp4",
+  prompt: brief.variations![0]!.prompt,
+});
+```
+
+`segments` and `variations` are both optional on the type — a `processing` or
+`failed` poll carries neither — so guard with `?? []` rather than asserting.
+
+### CLI (`npm install -g sonilo-cli` or `pip install sonilo-cli`)
+
+```bash
+sonilo video-analysis --video trailer.mp4 --prompt "focus on the chase" --variants 2
+```
+
+The brief goes to **stdout as JSON**, so it pipes:
+
+```bash
+sonilo video-analysis --video trailer.mp4 --output brief.json
+sonilo video-to-music --video trailer.mp4 --prompt "$(jq -r '.variations[0].prompt' brief.json)"
+```
+
+`--output` is the only way this command writes a file, and it writes the brief,
+not media.
+
+### cURL (raw REST API, no MCP host)
+
+```bash
+curl -X POST "https://api.sonilo.com/v1/video-analysis" \
+  -H "Authorization: Bearer $SONILO_API_KEY" \
+  -F "video=@trailer.mp4" \
+  -F "variants_num=2"
+# -> 202 {"task_id": "...", "status": "processing"}
+
+curl "https://api.sonilo.com/v1/tasks/<task_id>" -H "Authorization: Bearer $SONILO_API_KEY"
+```
+
+It is async: the POST returns a `task_id`, and the brief arrives on the task
+poll. `video_url` works instead of an uploaded file — pass one or the other,
+never both.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `analyze_video(video_path? \| video_url?, prompt?, variants_num?)` | Analyze a video and return a creative brief for scoring it. Generates nothing and writes no file. `video_path` exists on the local server only — the hosted server is `video_url`-only. |
+
+## Parameters
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|-------|
+| `video_path` | string | — | Local server only. Absolute path, or relative to `SONILO_MCP_BASE_PATH`. Max **600s (10 min)**, subject to the account's upload-size cap. |
+| `video_url` | string | — | HTTP(S) URL to a video file. Exactly one of `video_path`/`video_url`. The only input the hosted server accepts. |
+| `prompt` | string | — | Optional guidance for the analysis, e.g. "focus on the chase". Max 2000 characters. Steers what the analysis pays attention to; it is not the generation prompt. |
+| `variants_num` | int | `1` | 1–5. How many independent briefs to author for the same video — different creative directions, not rewordings of one. **Billed per brief**, so 3 variations cost 3×. Confirm the number with the user before calling. |
+
+## What comes back
+
+```json
+{
+  "task_id": "…",
+  "status": "succeeded",
+  "segments": [
+    {"start": 0, "end": 12, "label": "intro", "prompt": "sparse piano, rising"},
+    {"start": 12, "end": 30, "label": "none", "prompt": "full strings, driving"}
+  ],
+  "variations": [
+    {"prompt": "cinematic strings, 90bpm, building to a brass hit"},
+    {"prompt": "lo-fi hip hop, warm keys, steady throughout"}
+  ]
+}
+```
+
+- **`variations[i].prompt`** is the payload: pass it verbatim as the `prompt` of `video_to_music`, `video_to_sfx`, `video_to_sound`, or their video-to-video counterparts. It is written to be used as-is — do not paraphrase it.
+- **`segments`** are whole-second bounds with a per-stretch direction. `label` is one of the music section labels, or the string `"none"`. Useful for reading the video's structure back to the user; note the **music** `segments` parameter takes `{start, prompt, label}` (no `end`) and the **SFX** one takes `{start, end, prompt}`, so a brief segment is not a drop-in for either — see the [video-to-music](../video-to-music) and [video-to-sfx](../video-to-sfx) skills for each shape.
+
+## Workflow Tips
+
+- **Show, then generate.** With `variants_num > 1`, print the variations and let the user pick before spending on a generation. That is the whole point of paying for the analysis.
+- **The prompt parameter is not the music prompt.** `prompt` here tells the analyzer what to look at; the music prompt is what comes *back*. Passing "cinematic strings" as `prompt` narrows the analysis, it doesn't set the score.
+- **Cheap relative to a wrong generation.** A 10-second billing floor plus one brief usually costs less than one rerolled video-to-video render — but say the price before calling either way.
+- **Duration cap is 600s**, more generous than every generation endpoint (360s for music, 180s for SFX/sound/dubbing). A video can be analyzable but too long to score in one call.
+- **Content restriction:** as everywhere in Sonilo, prompts cannot reference specific artists, bands, or copyrighted lyrics — and the returned variations will not either.
+
+## Recovering a Timed-Out Call
+
+`analyze_video` is async: the backend accepts and charges the task, then a
+worker runs it. If the call times out, the error message includes a `task_id`
+and the brief is still coming. Call `get_sfx_task(task_id)` —
+`get_generation_task(task_id)` on the hosted server — to retrieve it; see the
+[task-recovery](../task-recovery) skill. Because there is no file to download,
+recovery hands back the brief itself, inline.
+
+Do **not** re-run `analyze_video` after a timeout. That is a second charge for
+a brief you already own.
+
+## Error Handling
+
+Common errors: `401` invalid key, `402` insufficient balance / trial exhausted,
+`413` file too large, `422` invalid parameters (video over the 600 s cap, a
+video with no video stream, `variants_num` outside 1–5), `429` rate limit. A
+failed analysis carries `error.code` `ANALYSIS_FAILED` and is refunded. `503`
+means video analysis is temporarily disabled server-side — it is not a key or
+balance problem and no retry loop will fix it. See the [account](../account)
+skill to check trial/usage before a call.

--- a/video-to-music/SKILL.md
+++ b/video-to-music/SKILL.md
@@ -147,6 +147,7 @@ generate once, iterate on the prompt, not on rerolls.
 - **Several takes in one go:** `variants_num=3` returns three distinct directions for one request instead of three re-rolls. It costs 3×, and it is never free-trial covered — say the price before calling.
 - **Duration:** always matched to the source video automatically — don't ask for it.
 - **Need SFX too?** To generate music **and** sound effects for the same video in one balanced, single-charge call, use [video-to-sound](../video-to-sound) rather than calling this and [video-to-sfx](../video-to-sfx) separately.
+- **Don't know what it should sound like?** Run [video-analysis](../video-analysis) first: one call returns a section plan plus ready-to-use generation prompts read off the footage, which beats guessing a prompt and rerolling. It is a paid call that generates nothing, so use it when the brief is genuinely unclear — not when the user already told you what they want.
 - **Content restriction:** prompts cannot reference specific artists, bands, or copyrighted lyrics.
 
 ## Recovering a Timed-Out Call

--- a/video-to-sfx/SKILL.md
+++ b/video-to-sfx/SKILL.md
@@ -145,6 +145,7 @@ runs auto-refund, but your own retry is a new charge.
 - **Prompting:** be specific and combine elements — "Heavy rain on a tin roof" beats "Rain".
 - **Don't confuse this with music.** For a background score or soundtrack, use [video-to-music](../video-to-music) instead. To generate both music and SFX together in one balanced, single-charge call, use [video-to-sound](../video-to-sound).
 - **No footage?** [text-to-sfx](../text-to-sfx) generates a single clip from a description alone.
+- **Don't know what it should sound like?** Run [video-analysis](../video-analysis) first: one call returns a section plan plus ready-to-use generation prompts read off the footage, which beats guessing a prompt and rerolling. It is a paid call that generates nothing, so use it when the brief is genuinely unclear — not when the user already told you what they want.
 
 ## Recovering a Timed-Out Call
 

--- a/video-to-sound/SKILL.md
+++ b/video-to-sound/SKILL.md
@@ -147,6 +147,7 @@ one balanced call, both crafts apply:
 - **For `video_to_video_sound`, the source audio is dropped unless you say otherwise.** `keep_original_sound=true` keeps the whole original track under the generated mix; `preserve_speech=true` keeps only the isolated speech. If a user reports "my dialogue disappeared", this is the fix.
 - Only the **combined mixed result** is saved. The individual music/SFX/processed stems exist in the task body on the backend but are deliberately not downloaded — four files per call would bury the one the user actually wants. If stems are needed, call the REST API directly and inspect the task body.
 - Want the video back with the soundtrack baked in? Use `video_to_video_sound` instead of `video_to_sound`.
+- **Don't know what it should sound like?** Run [video-analysis](../video-analysis) first: one call returns a section plan plus ready-to-use generation prompts read off the footage, which beats guessing a prompt and rerolling. It is a paid call that generates nothing, so use it when the brief is genuinely unclear — not when the user already told you what they want.
 
 ## Recovering a Timed-Out Call
 


### PR DESCRIPTION
Adds a skill for `POST /v1/video-analysis` (tool: `analyze_video`), plus the surface and cross-reference updates it implies.

## ⚠️ Do not merge before sonilo-mcp 0.17.0 is on PyPI

CI installs the **published** `sonilo-mcp` and diffs its live tool surface against `tests/tool_surface.json`. This branch records `analyze_video` in the `local` block, so the drift check will fail until sonilo-ai/sonilo-mcp#28 is merged and released. That is the check working as designed — it is exactly what stops this repo from documenting a tool users don't have yet.

The `hosted` block is already true: `analyze_video(video_url, prompt, variants_num)` is live on the deployed backend-mcp server, verified against it directly.

## What the skill says

The skill's job is to tell an agent **when not to reach for it**. Analysis is a paid call that produces nothing, so it leads with the three cases where it earns its charge — the user can't describe what they want, a first generation missed, or the video has real sections — and says plainly to skip it when the user already gave a prompt.

Two facts it has to carry that no other skill does:

- **The result is text, not a file.** The MCP tool writes nothing, the CLI prints JSON to stdout, and the SDK results have no `save()`. Every other Sonilo skill ends in "saved to `<path>`", so this is stated everywhere it could surprise.
- **Input differs by MCP server.** The hosted server is `video_url`-only; local `sonilo-mcp` 0.17.0 also takes `video_path`. An agent on the hosted server reaching for `video_path` gets an unknown-parameter error, so the difference is called out rather than left to be discovered.

## Also in this PR

- Cross-references from `video-to-music`, `video-to-sfx` and `video-to-sound` pointing at it as the optional pre-step for footage nobody can brief.
- `task-recovery` now covers `analyze_video` — its recovery path is the one that returns a brief inline instead of downloading a file.
- `tests/tool_surface.json`: `analyze_video` on both servers, the `video-analysis` CLI command and its flags, and `variants_num` in `must_document` (it multiplies the charge).
- `references/api-claims.md`: a `video_analysis` section — the 600 sec cap (the most generous of any endpoint), the 1-5 variant range, the 10-second billing floor, the `PROMPT_SERVICE_ENABLED` 503, and the fact that the upstream's `negative_prompt`/`thinking`/titles are stripped by product decision and not recoverable.
- `plugin.json` 2.0.0 → 2.1.0 with the new skill registered.

## Testing

`python tests/validate.py` — all checks pass; 17 files, 12 skills, 14 hosted tools, 15 local tools.

## Companion PRs

- sonilo-ai/sonilo-mcp#28 — the `analyze_video` tool (**must ship first**)
- sonilo-ai/sonilo-python#30 — `client.video_analysis` + `sonilo video-analysis`
- sonilo-ai/sonilo-js#55 — `client.videoAnalysis` + `sonilo video-analysis`