### PR TITLE
Document dubbing's 5-minute source cap

### DIFF
--- a/auto-dubbing/SKILL.md
+++ b/auto-dubbing/SKILL.md
@@ -114,7 +114,7 @@ curl -X POST "https://api.sonilo.com/v1/dubbing" \
 
 | Parameter | Type | Default | Notes |
 |-----------|------|---------|-------|
-| `video_path` | string | — | `.mp4/.mov/.webm/.m4v/.gif` (gif must be animated). Max **180s (3 min)**, subject to the account's upload-size cap. |
+| `video_path` | string | — | `.mp4/.mov/.webm/.m4v/.gif` (gif must be animated). Max **300s (5 min)**, subject to the account's upload-size cap. |
 | `video_url` | string | — | **Must be https** (not just http). Exactly one of `video_path`/`video_url`. |
 | `languages` | list[str] | `["zh_cn", "es", "fr"]` | Target language codes. Supported: `en`, `zh_cn`, `ja`, `ko`, `pt`, `es`, `de`, `fr`, `it`, `ru`. **Omitting this still dubs into 3 languages and bills for 3** — pass an explicit single-element list if the user only wants one. |
 | `output_directory` | string | `SONILO_MCP_BASE_PATH` | Absolute, or relative to the base path. |

--- a/references/api-claims.md
+++ b/references/api-claims.md
@@ -27,7 +27,7 @@ Every numeric limit and behavior claim used by the skills in this repo, verified
 Added 2026-08-16 with the endpoint itself; verified against the shipped backend and the live
 `platform.sonilo.com/openapi.json`, not against an engineering conversation.
 
-- [x] **Cap 600 s** — the most generous cap of any endpoint (music is 360 s, SFX/sound/dubbing 180 s). A video can be analyzable and still too long to score in one call. Over-cap = **422 reject**.
+- [x] **Cap 600 s** — the most generous cap of any endpoint (music is 360 s, dubbing 300 s, SFX/sound 180 s). A video can be analyzable and still too long to score in one call. Over-cap = **422 reject**.
 - [x] **Generates nothing.** No audio, no video, no artifact. The result is `segments` (whole-second `start`/`end`, a `label`, and a per-stretch `prompt`) plus `variations` (one generation `prompt` each). This is the only Sonilo task type with no media in its envelope, which is why every client surfaces it as text rather than a saved file.
 - [x] `variants_num` **1-5**, billed per brief — narrower than the music endpoints' 1-10. `prompt` ≤ 2000 chars, and it steers the **analysis**, not the score.
 - [x] **10-second billing floor**: a fixed per-request output cost regardless of clip length, so a 3-second clip costs the same as a 10-second one.

--- a/tests/tool_surface.json
+++ b/tests/tool_surface.json
@@ -455,6 +455,7 @@
     "_comment": "Strings that were true once. Each maps to what to say instead.",
     "sks_": "keys are `sk-` prefixed",
     "narrower tool coverage": "the hosted server carries the full tool set",
-    "SONILO_API_KEY is required": "a key is optional since sonilo-mcp 0.16.0 \u2014 `sonilo login` also works"
+    "SONILO_API_KEY is required": "a key is optional since sonilo-mcp 0.16.0 \u2014 `sonilo login` also works",
+    "SFX/sound/dubbing": "dubbing's cap is 300 s (5 min); only SFX and sound are still 180 s"
   }
 }

--- a/video-analysis/SKILL.md
+++ b/video-analysis/SKILL.md
@@ -185,7 +185,7 @@ never both.
 - **Show, then generate.** With `variants_num > 1`, print the variations and let the user pick before spending on a generation. That is the whole point of paying for the analysis.
 - **The prompt parameter is not the music prompt.** `prompt` here tells the analyzer what to look at; the music prompt is what comes *back*. Passing "cinematic strings" as `prompt` narrows the analysis, it doesn't set the score.
 - **Cheap relative to a wrong generation.** A 10-second billing floor plus one brief usually costs less than one rerolled video-to-video render — but say the price before calling either way.
-- **Duration cap is 600s**, more generous than every generation endpoint (360s for music, 180s for SFX/sound/dubbing). A video can be analyzable but too long to score in one call.
+- **Duration cap is 600s**, more generous than every generation endpoint (360s for music, 300s for dubbing, 180s for SFX/sound). A video can be analyzable but too long to score in one call.
 - **Content restriction:** as everywhere in Sonilo, prompts cannot reference specific artists, bands, or copyrighted lyrics — and the returned variations will not either.
 
 ## Recovering a Timed-Out Call


### PR DESCRIPTION
The API raised `/v1/dubbing` from 180 to 300 sec (5 min); it is live in production as of today.

## Changes

- `auto-dubbing/SKILL.md` — the `video_path` row's "Max **180s (3 min)**".
- `video-analysis/SKILL.md` and `references/api-claims.md` — both argue that video-analysis's 600 sec cap is the most generous by listing everyone else's, and both put dubbing in the "180s for SFX/sound/dubbing" group. **video-analysis itself is unchanged** — it only cited the number.

## Guard

`SFX/sound/dubbing` is now a banned token, so that grouping cannot come back. A bare "180s" ban would be wrong: SFX and sound really are still 180, and both skills say so correctly.

Verified the guard bites — reintroducing the old phrasing in `video-analysis/SKILL.md` fails the validator with the replacement text, and removing it passes again.

`python tests/validate.py`: checked 17 files, 12 skills, 14 hosted tools, 15 local tools — all checks passed.