### PR TITLE
video-analysis: the cap is 360 s, and it always was

### DIFF
--- a/references/api-claims.md
+++ b/references/api-claims.md
@@ -27,7 +27,7 @@ Every numeric limit and behavior claim used by the skills in this repo, verified
 Added 2026-08-16 with the endpoint itself; verified against the shipped backend and the live
 `platform.sonilo.com/openapi.json`, not against an engineering conversation.
 
-- [x] **Cap 600 s** — the most generous cap of any endpoint (music is 360 s, dubbing 300 s, SFX/sound 180 s). A video can be analyzable and still too long to score in one call. Over-cap = **422 reject**.
+- [x] **Cap 360 s** (lowered from 600 s on 2026-08-20, sonilo-api-dashboard#292) — tied with music, above dubbing 300 s and SFX/sound 180 s. The old 600 s was never reachable: the same internal 360 s probe backstop noted under `video_to_sfx` rejected every longer source first, so 360-600 s videos were refused with a misleading "could not read the video". A video can still be analyzable and too long to score with SFX or sound in one call. Over-cap = **422 reject**.
 - [x] **Generates nothing.** No audio, no video, no artifact. The result is `segments` (whole-second `start`/`end`, a `label`, and a per-stretch `prompt`) plus `variations` (one generation `prompt` each). This is the only Sonilo task type with no media in its envelope, which is why every client surfaces it as text rather than a saved file.
 - [x] `variants_num` **1-5**, billed per brief — narrower than the music endpoints' 1-10. `prompt` ≤ 2000 chars, and it steers the **analysis**, not the score.
 - [x] **10-second billing floor**: a fixed per-request output cost regardless of clip length, so a 3-second clip costs the same as a 10-second one.

--- a/video-analysis/SKILL.md
+++ b/video-analysis/SKILL.md
@@ -155,7 +155,7 @@ never both.
 
 | Parameter | Type | Default | Notes |
 |-----------|------|---------|-------|
-| `video_path` | string | — | Local server only. Absolute path, or relative to `SONILO_MCP_BASE_PATH`. Max **600s (10 min)**, subject to the account's upload-size cap. |
+| `video_path` | string | — | Local server only. Absolute path, or relative to `SONILO_MCP_BASE_PATH`. Max **360s (6 min)**, subject to the account's upload-size cap. |
 | `video_url` | string | — | HTTP(S) URL to a video file. Exactly one of `video_path`/`video_url`. The only input the hosted server accepts. |
 | `prompt` | string | — | Optional guidance for the analysis, e.g. "focus on the chase". Max 2000 characters. Steers what the analysis pays attention to; it is not the generation prompt. |
 | `variants_num` | int | `1` | 1–5. How many independent briefs to author for the same video — different creative directions, not rewordings of one. **Billed per brief**, so 3 variations cost 3×. Confirm the number with the user before calling. |
@@ -185,7 +185,7 @@ never both.
 - **Show, then generate.** With `variants_num > 1`, print the variations and let the user pick before spending on a generation. That is the whole point of paying for the analysis.
 - **The prompt parameter is not the music prompt.** `prompt` here tells the analyzer what to look at; the music prompt is what comes *back*. Passing "cinematic strings" as `prompt` narrows the analysis, it doesn't set the score.
 - **Cheap relative to a wrong generation.** A 10-second billing floor plus one brief usually costs less than one rerolled video-to-video render — but say the price before calling either way.
-- **Duration cap is 600s**, more generous than every generation endpoint (360s for music, 300s for dubbing, 180s for SFX/sound). A video can be analyzable but too long to score in one call.
+- **Duration cap is 360s (6 min)**, the same as the music endpoints, above dubbing (300s) and the SFX/sound ones (180s). Lowered from 600s on 2026-08-20 — 600s was never real, since a shared 360s probe ceiling had always rejected longer sources first. A video can still be analyzable but too long to score with SFX or sound in one call.
 - **Content restriction:** as everywhere in Sonilo, prompts cannot reference specific artists, bands, or copyrighted lyrics — and the returned variations will not either.
 
 ## Recovering a Timed-Out Call
@@ -203,7 +203,7 @@ a brief you already own.
 ## Error Handling
 
 Common errors: `401` invalid key, `402` insufficient balance / trial exhausted,
-`413` file too large, `422` invalid parameters (video over the 600 s cap, a
+`413` file too large, `422` invalid parameters (video over the 360 s cap, a
 video with no video stream, `variants_num` outside 1–5), `429` rate limit. A
 failed analysis carries `error.code` `ANALYSIS_FAILED` and is refunded. `503`
 means video analysis is temporarily disabled server-side — it is not a key or


### PR DESCRIPTION
Follows sonilo-api-dashboard#292, deployed to prod 2026-08-20.

## What changed on the API

`/v1/video-analysis` restated its source-video cap as **360 s (6 min)**, down from a documented 600 s.

## Why this is a correction, not a tightening

`references/api-claims.md` already recorded the mechanism, twice — under `video_to_music`: *"All video endpoints share ffprobe-based 360 s"*, and under `video_to_sfx`: *"Internal 360 s probe backstop exists"*. That backstop runs **before** each endpoint's own check, so video-analysis's 600 s was never reachable. A 360-600 s video was already being refused — with a misleading "could not read the video", which the API also fixed.

So no caller loses a capability here. What they gain is an accurate number and an accurate error.

## Files

- `video-analysis/SKILL.md` — the `video_path` row, the error-handling list, and the duration bullet.
- `references/api-claims.md` — the cap claim, now dated and cross-referenced to the backstop entry it contradicted.

The **"more generous than every generation endpoint"** framing had to go, not just its number: 360 s ties with music rather than beating everything. The useful half survives — a video can be analyzable and still too long to score with SFX or sound in one call.

## Validation

`python tests/validate.py` → `checked 17 files, 12 skills, 14 hosted tools, 15 local tools / all checks passed`. The recorded tool surface carries names and parameters, not this prose, so this PR is independent of the sonilo-mcp release (sonilo-mcp#31).