### PR TITLE
Offer the seven new dubbing languages in the auto-dubbing skill

### DIFF
--- a/auto-dubbing/SKILL.md
+++ b/auto-dubbing/SKILL.md
@@ -116,7 +116,7 @@ curl -X POST "https://api.sonilo.com/v1/dubbing" \
 |-----------|------|---------|-------|
 | `video_path` | string | — | `.mp4/.mov/.webm/.m4v/.gif` (gif must be animated). Max **300s (5 min)**, subject to the account's upload-size cap. |
 | `video_url` | string | — | **Must be https** (not just http). Exactly one of `video_path`/`video_url`. |
-| `languages` | list[str] | `["zh_cn", "es", "fr"]` | Target language codes. Supported: `en`, `zh_cn`, `ja`, `ko`, `pt`, `pt_br`, `es`, `es_419`, `de`, `fr`, `it`, `ru`, `th`. `pt_br` is Brazilian Portuguese and `es_419` Latin American Spanish; plain `pt`/`es` are unqualified, so ask which the user wants when it matters. **Omitting this still dubs into 3 languages and bills for 3** — pass an explicit single-element list if the user only wants one. |
+| `languages` | list[str] | `["zh_cn", "es", "fr"]` | Target language codes. Supported: `en`, `zh_cn`, `ja`, `ko`, `pt`, `pt_br`, `es`, `es_419`, `de`, `fr`, `it`, `ru`, `th`, `ar`, `tr`, `vi`, `id`. `pt_br` is Brazilian Portuguese and `es_419` Latin American Spanish; plain `pt`/`es` are unqualified, so ask which the user wants when it matters. `ar` is unqualified Arabic rather than a country dialect, so there is nothing to ask there. **Omitting this still dubs into 3 languages and bills for 3** — pass an explicit single-element list if the user only wants one. |
 | `output_directory` | string | `SONILO_MCP_BASE_PATH` | Absolute, or relative to the base path. |
 
 ## Workflow Tips

--- a/auto-dubbing/SKILL.md
+++ b/auto-dubbing/SKILL.md
@@ -116,7 +116,7 @@ curl -X POST "https://api.sonilo.com/v1/dubbing" \
 |-----------|------|---------|-------|
 | `video_path` | string | — | `.mp4/.mov/.webm/.m4v/.gif` (gif must be animated). Max **300s (5 min)**, subject to the account's upload-size cap. |
 | `video_url` | string | — | **Must be https** (not just http). Exactly one of `video_path`/`video_url`. |
-| `languages` | list[str] | `["zh_cn", "es", "fr"]` | Target language codes. Supported: `en`, `zh_cn`, `ja`, `ko`, `pt`, `es`, `de`, `fr`, `it`, `ru`. **Omitting this still dubs into 3 languages and bills for 3** — pass an explicit single-element list if the user only wants one. |
+| `languages` | list[str] | `["zh_cn", "es", "fr"]` | Target language codes. Supported: `en`, `zh_cn`, `ja`, `ko`, `pt`, `pt_br`, `es`, `es_419`, `de`, `fr`, `it`, `ru`, `th`. `pt_br` is Brazilian Portuguese and `es_419` Latin American Spanish; plain `pt`/`es` are unqualified, so ask which the user wants when it matters. **Omitting this still dubs into 3 languages and bills for 3** — pass an explicit single-element list if the user only wants one. |
 | `output_directory` | string | `SONILO_MCP_BASE_PATH` | Absolute, or relative to the base path. |
 
 ## Workflow Tips


### PR DESCRIPTION
The dubbing pipeline gained seven languages in two batches — `pt_br`, `es_419`, `th`, then `ar`, `tr`, `vi`, `id`. The auto-dubbing skill still listed ten.

This branch already carried the first three (unpushed as a PR until now); this adds the second four, so one PR covers all seven.

## Why it matters

The parameter table is the list an agent reads when it proposes languages to a user. A code missing from it is a code no agent offers, whatever the API accepts — the skill is the bottleneck, not the backend.

## Notes

`pt_br` and `es_419` are additions to `pt` and `es`, not replacements, so the table keeps the "ask which the user wants" instruction for those.

`ar` is unqualified Arabic rather than one of HeyGen's seventeen country variants, so unlike `pt`/`es` it carries no such ambiguity — the note says so explicitly, since the skill's standing instruction is to ask whenever a code is ambiguous and an agent would otherwise ask a question with no answer.

## Related

- sonilo-api-dashboard: backend `SUPPORTED_LANGUAGES` + docs (in progress)
- sonilo-js#67, sonilo-python#35, sonilo-mcp#34

🤖 Generated with [Claude Code](https://claude.com/claude-code)